### PR TITLE
get car positions from lap chart PDF (fix #19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 # Data files
 data
 *.pkl
+
+# Mac shit
+.DS_Store

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -619,8 +619,16 @@ class RaceParser:
         doc = pymupdf.open(self.lap_chart_file)
         df = []
         for page in doc:
-            t = page.search_for('Race Lap Chart')[0].y1  # The table is below "Race Lap Chart"
-            b = page.search_for('page')[0].y0            # The table is above "page x of y"
+            t = page.search_for('Lap Chart')[0].y1  # The table is below "Race Lap Chart"
+            b = page.search_for('page')
+            if b:  # The table is above "page x of y"
+                b = b[0].y0
+            else:  # Or the bottom of the page (the © logo)
+                b = page.search_for('©')
+                if b:
+                    b = b[0].y0
+                else:
+                    raise ValueError(f'Cannot find © on p. {page.number} in {self.lap_chart_file}')
 
             # Left boundary is the leftmost "LAP x"
             l = page.search_for('LAP', clip=(0, t, page.bound()[2], b))[0].x0
@@ -653,7 +661,7 @@ class RaceParser:
             # Below "POS" we have rows GRID, LAP 1, LAP 2, ...
             laps = page.get_text('dict', clip=(l - 5, pos.y1, col_seps[1], b))
             assert len(laps['blocks']) == 1, f'Error in parsing laps in leftmost col. on ' \
-                                             f'page {page.number} in {self.lap_chart_file}'
+                                             f'p.{page.number} in {self.lap_chart_file}'
             laps = laps['blocks'][0]['lines']
             assert laps, \
                 f'Expected some laps below "POS" on page {page.number} in ' \
@@ -697,130 +705,290 @@ class RaceParser:
         b, r = doc[0].bound()[3], doc[0].bound()[2]
         df = []
         for page in doc:
-            # Get the position of "LAP" and "TIME" on the page. Can have multiple of them, all of
-            # which should have approx. the same y-coord. The tables are below these texts
-            h = page.search_for('Race Lap Analysis')[0].y1
+            # Get the position of "LAP" and "TIME" on the page. Can have multiple of them. The
+            # tables are below these texts
+            h = page.search_for('Lap Analysis')[0].y1
             laps = page.search_for('LAP', clip=(0, h, r, b))
             times = page.search_for('TIME', clip=(0, h, r, b))
             assert len(laps) == len(times), \
                 f'#. of "LAP" and #. of "TIME" do not match on p.{page.number} in ' \
                 f'{self.lap_analysis_file}'
-            for i in range(len(laps) - 1):
-                assert np.isclose(laps[i].y1, laps[i + 1].y1, atol=1) and \
-                          np.isclose(times[i].y1, times[i + 1].y1, atol=1), \
-                    f'y-coord. of "LAP" and "TIME" do not match on p.{page.number} in ' \
-                    f'{self.lap_analysis_file}'
 
-            # Horizontally, three drivers share the full width of the page, side by side
+            # If it's race, then only three drivers (or less) on one page. And all of them should
+            # start from the same y-coord. and have the same y-coord. for "LAP" and "TIME"
+            if self.session == 'race':
+                assert len(laps) <= 6, f'Expected at most 6 "LAP" on p.{page.number} in ' \
+                                       f'{self.lap_analysis_file}. Found {len(laps)}'
+                for i in range(len(laps) - 1):
+                    assert np.isclose(laps[i].y1, laps[i + 1].y1, atol=1) and \
+                              np.isclose(times[i].y1, times[i + 1].y1, atol=1), \
+                        f'y-coord. of "LAP" and "TIME" do not match on p.{page.number} in ' \
+                        f'{self.lap_analysis_file}: {laps[i].y1} vs {laps[i + 1].y1} vs ' \
+                        f'{times[i].y1} vs {times[i + 1].y1}'
+            # If it's sprint, then can have many more drivers in total. However, in one row, it's
+            # still three drivers side by side, and the last row may have less, and in each row,
+            # "LAP" and "TIME" should have the same y-coord.
+            else:
+                laps.sort(key=lambda x: x.y0)
+                times.sort(key=lambda x: x.y0)
+                for i in range(0, len(laps) - 1, 6):
+                    for j in range(6):
+                        if i + j == len(laps):
+                            break
+                        assert np.isclose(laps[i + j].y0, laps[i].y0, atol=1) and \
+                                np.isclose(times[i + j].y0, times[i].y0, atol=1), \
+                            f'y-coord. of "LAP" and "TIME" do not match in row {i} on ' \
+                            f'p.{page.number} in {self.lap_analysis_file}: {laps[i + j].y0} vs ' \
+                            f'{laps[i].y0} vs {times[i + j].y0} vs {times[i].y0}'
+
+            # Horizontally, three drivers share the full width of the page, side by side. If it's
+            # race, then three drivers (or less) on one page
             # See QualifyingParser._parse_lap_times() for detailed explanation
-            w = r / 3
-            for i in range(3):
-                # Driver's name is below "Race Lap Analysis" and above the table
-                l = i * w
-                r = (i + 1) * w
-                t = min([i.y0 for i in laps] + [i.y0 for i in times])
-                driver = page.get_text('block', clip=(l, h, r, t)).strip()
-                if not driver:
-                    continue
-                    # TODO: may want a test here. Every row above should have exactly three drivers
-                car_no, driver = driver.split('\n', 1)
+            if self.session == 'race':
+                w = r / 3
+                for i in range(3):
+                    # Driver's name is below "Race Lap Analysis" and above the table
+                    l = i * w
+                    r = (i + 1) * w
+                    t = min([i.y0 for i in laps] + [i.y0 for i in times])
+                    driver = page.get_text('block', clip=(l, h, r, t)).strip()
+                    if not driver:
+                        continue
+                        # TODO: may want a test here. Every row above should have exactly 3 drivers
+                    car_no, driver = driver.split('\n', 1)
 
-                # Each driver has two tables side by side. We parse the tables by manually
-                # specifying row and col. positions (harningle/fia-doc#17)
-                # TODO: need to check if always have two tables. A good edge case is Spa 2021
+                    # Each driver has two tables side by side. We parse the tables by manually
+                    # specifying row and col. positions (harningle/fia-doc#17)
+                    # TODO: need to check if always have two tables. A good edge case is Spa 2021
 
-                # Find the horizontal lines under which the tables are located
+                    # Find the horizontal lines under which the tables are located
+                    page = Page(page)
+                    t = max([i.y1 for i in laps] + [i.y1 for i in times])
+                    lines = [i for i in page.get_drawings_in_bbox((l, t, r, t + 10))
+                             if np.isclose(i['rect'].y0, i['rect'].y1, atol=1)]
+                    assert len(lines) >= 1, f'Expected at least one horizontal line for ' \
+                                            f'table(s) in col. {i} in page {page.number} in ' \
+                                            f'{self.history_chart_file}. Found none'
+                    assert np.allclose([i['rect'].y0 for i in lines],
+                                       lines[0]['rect'].y0,
+                                       atol=1), \
+                        f'Horizontal lines for table(s) in col. {i} in page {page.number} in ' \
+                        f'{self.history_chart_file} are not at the same y-position'
+
+                    # Concat lines.
+                    lines.sort(key=lambda x: x['rect'].x0)
+                    rect = lines[0]['rect']
+                    top_lines = [(rect.x0, rect.y0, rect.x1, rect.y1)]
+                    for line in lines[1:]:
+                        rect = line['rect']
+                        prev_line = top_lines[-1]
+                        # If one line ends where the other starts, they are the same line
+                        if np.isclose(rect.x0, prev_line[2], atol=1):
+                            top_lines[-1] = (prev_line[0], prev_line[1], rect.x1, prev_line[3])
+                        # If one line starts where the other ends, they are the same line
+                        elif np.isclose(rect.x1, prev_line[0], atol=1):
+                            top_lines[-1] = (rect.x0, prev_line[1], prev_line[2], prev_line[3])
+                        # Otherwise, it's a new line
+                        else:
+                            top_lines.append((rect.x0, rect.y0, rect.x1, rect.y1))
+                    assert len(top_lines) in [1, 2], \
+                        f'Expected at most two horizontal lines for table(s) in col. {i} in ' \
+                        f'p.{page.number} in {self.history_chart_file}. Found {len(top_lines)}'
+
+                    # Find the column separators
+                    col_seps = []
+                    for line in top_lines:
+                        no = page.search_for('LAP', clip=(line[0], line[1] - 15, line[2], line[3]))
+                        assert len(no) == 1, \
+                            f'Expected exactly one "LAP" above the top line at ' \
+                            f'({line[0], line[1], line[2], line[3]}) in page {page.number} in ' \
+                            f'{self.history_chart_file}. Found {len(no)}'
+                        col_seps.append([
+                            (line[0], no[0].x1),
+                            (no[0].x1, (line[0] + line[2]) / 2 - 5),
+                            ((line[0] + line[2]) / 2 - 5, line[2])
+                        ])
+
+                    # Find the white and grey rectangles under the top lines. Each row is either
+                    # coloured/filled in either white or grey, so we can get the row's top and
+                    # bottom y-positions from these rectangles
+                    rects = [i for i in page.get_drawings_in_bbox((l, t, r, b))
+                             if i['rect'].y1 - i['rect'].y0 > 10]
+                    ys = [j for i in rects for j in [i['rect'].y0, i['rect'].y1]]
+                    ys.sort()
+                    row_seps = [ys[0]]
+                    for y in ys[1:]:
+                        if y - row_seps[-1] > 10:
+                            row_seps.append(y)
+                    row_seps = [(row_seps[i], row_seps[i + 1]) for i in range(len(row_seps) - 1)]
+
+                    # Finally we are good to parse the tables using these separators
+                    temp = []
+                    for cols in col_seps:
+                        tab, superscript, cross_out = page.parse_table_by_grid(
+                            vlines=cols, hlines=row_seps
+                        )
+                        assert (len(superscript) == 0) and len(cross_out) == 0, \
+                            f'Some superscript(s) or crossed out text(s) found in table at ' \
+                            f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
+                            f'{row_seps[-1][1]:.1f}) in page {page.number} in ' \
+                            f'{self.history_chart_file}. But we expect none'
+                        assert tab.shape[1] == 3, \
+                            f'Expected three columns (LAP, pit or not, lap time) in table at ' \
+                            f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
+                            f'{row_seps[-1][1]:.1f}) in page {page.number} in ' \
+                            f'{self.history_chart_file}. Found {len(tab)}'
+                        tab.columns = ['lap', 'pit', 'lap_time']
+
+                        # Drop empty row
+                        """
+                        This is because the two side-by-side tables may not have the same amount of
+                        rows. E.g., there are 11 laps, and the left table will have 6 and the right
+                        table has 5 rows. The right table will have an empty row at the bottom, so
+                        drop it here
+                        """
+                        tab = tab[tab.lap != '']
+                        temp.append(tab)
+
+                    # One driver may have multiple tables. Concatenate them
+                    temp = pd.concat(temp, ignore_index=True)
+                    temp['car_no'] = car_no
+                    temp['driver'] = driver
+                    df.append(temp)
+            # If it's sprint, then can have many rows on one page, and each row has three drivers
+            # side by side
+            else:
+                # y-coords. of "LAP" and "TIME". They are the top of each table
                 page = Page(page)
-                t = max([i.y1 for i in laps] + [i.y1 for i in times])
-                lines = [i for i in page.get_drawings_in_bbox((l, t, r, t + 10))
-                         if np.isclose(i['rect'].y0, i['rect'].y1, atol=1)]
-                assert len(lines) >= 1, f'Expected at least one horizontal line for ' \
-                                        f'table(s) in col. {i} in page {page.number} in ' \
-                                        f'{self.history_chart_file}. Found none'
-                assert np.allclose([i['rect'].y0 for i in lines], lines[0]['rect'].y0, atol=1), \
-                    f'Horizontal lines for table(s) in col. {i} in page {page.number} in ' \
-                    f'{self.history_chart_file} are not at the same y-position'
-
-                # Concat lines.
-                lines.sort(key=lambda x: x['rect'].x0)
-                rect = lines[0]['rect']
-                top_lines = [(rect.x0, rect.y0, rect.x1, rect.y1)]
-                for line in lines[1:]:
-                    rect = line['rect']
-                    prev_line = top_lines[-1]
-                    # If one line ends where the other starts, they are the same line
-                    if np.isclose(rect.x0, prev_line[2], atol=1):
-                        top_lines[-1] = (prev_line[0], prev_line[1], rect.x1, prev_line[3])
-                    # If one line starts where the other ends, they are the same line
-                    elif np.isclose(rect.x1, prev_line[0], atol=1):
-                        top_lines[-1] = (rect.x0, prev_line[1], prev_line[2], prev_line[3])
-                    # Otherwise, it's a new line
-                    else:
-                        top_lines.append((rect.x0, rect.y0, rect.x1, rect.y1))
-                assert len(top_lines) in [1, 2], \
-                    f'Expected at most two horizontal lines for table(s) in col. {i} in page ' \
-                    f'{page.number} in {self.history_chart_file}. Found {len(top_lines)}'
-
-                # Find the column separators
-                col_seps = []
-                for line in top_lines:
-                    no = page.search_for('LAP', clip=(line[0], line[1] - 15, line[2], line[3]))
-                    assert len(no) == 1, \
-                        f'Expected exactly one "LAP" above the top line at ' \
-                        f'({line[0], line[1], line[2], line[3]}) in page {page.number} in ' \
-                        f'{self.history_chart_file}. Found {len(no)}'
-                    col_seps.append([
-                        (line[0], no[0].x1),
-                        (no[0].x1, (line[0] + line[2]) / 2 - 5),
-                        ((line[0] + line[2]) / 2 - 5, line[2])
-                    ])
-
-                # Find the white and grey rectangles under the top lines. Each row is either
-                # coloured/filled in either white or grey, so we can get the row's top and bottom
-                # y-positions from these rectangles
-                rects = [i for i in page.get_drawings_in_bbox((l, t, r, b))
-                         if i['rect'].y1 - i['rect'].y0 > 10]
-                ys = [j for i in rects for j in [i['rect'].y0, i['rect'].y1]]
-                ys.sort()
-                row_seps = [ys[0]]
+                ys = [i.y1 for i in laps]
+                ys.sort()  # Sort these "LAP"'s from top to bottom
+                top_pos = [ys[0]]
                 for y in ys[1:]:
-                    if y - row_seps[-1] > 10:
-                        row_seps.append(y)
-                row_seps = [(row_seps[i], row_seps[i + 1]) for i in range(len(row_seps) - 1)]
+                    if y - top_pos[-1] > 10:
+                        top_pos.append(y)
 
-                # Finally we are good to parse the tables using these separators
-                temp = []
-                for cols in col_seps:
-                    tab, superscript, cross_out = page.parse_table_by_grid(
-                        vlines=cols, hlines=row_seps
-                    )
-                    assert (len(superscript) == 0) and len(cross_out) == 0, \
-                        f'Some superscript(s) or crossed out text(s) found in table at ' \
-                        f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
-                        f'{row_seps[-1][1]:.1f}) in page {page.number} in ' \
-                        f'{self.history_chart_file}. But we expect none'
-                    assert tab.shape[1] == 3, \
-                        f'Expected three columns (LAP, pit or not, lap time) in table at ' \
-                        f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
-                        f'{row_seps[-1][1]:.1f}) in page {page.number} in ' \
-                        f'{self.history_chart_file}. Found {len(tab)}'
-                    tab.columns = ['lap', 'pit', 'lap_time']
+                # Bottom of the table is the next "NO TIME", or the bottom of the page
+                ys = [i.y0 for i in laps]
+                ys.sort()
+                bottom_pos = [ys[0]]
+                for y in ys[1:]:
+                    if y - bottom_pos[-1] > 10:
+                        bottom_pos.append(y)
+                b = page.bound()[3]
+                bottom_pos.append(b)
+                bottom_pos = bottom_pos[1:]  # The first "NO TIME" is not the bottom of any table
 
-                    # Drop empty row
-                    """
-                    This is because the two side-by-side tables may not have the same amount of
-                    rows. E.g., there are 11 laps, and the left table will have 6 and the right
-                    table has 5 rows. The right table will have an empty row at the bottom, so
-                    drop it here
-                    """
-                    tab = tab[tab.lap != '']
-                    temp.append(tab)
+                # Find the tables located between each `top_pos` and `bottom_pos`
+                w = page.bound()[2]
+                for row in range(len(top_pos)):
+                    # Each row usually has three drivers. Iterate over drivers
+                    for col in range(3):
 
-                # One driver may have multiple tables. Concatenate them
-                temp = pd.concat(temp, ignore_index=True)
-                temp['car_no'] = car_no
-                temp['driver'] = driver
-                df.append(temp)
+                        # Find the driver name, which is located immediately above the table
+                        driver = page.get_text(
+                            'block',
+                            clip=(
+                                col * w / 3,        # Each driver occupies ~1/3 of the page width
+                                top_pos[row] - 30,  # Driver name is ~20-30 px above the table
+                                (col + 1) * w / 3,
+                                top_pos[row] - 10
+                            )
+                        ).strip()
+                        if not driver:
+                            continue
+                            # TODO: may want a test here. Every row above should have
+                            #       precisely three drivers
+                        car_no, driver = driver.split(maxsplit=1)
+
+                        # Find the horizontal line(s) below "NO" and "TIME". This is the top of the
+                        # table(s)
+                        bbox = (col * w / 3, top_pos[row], (col + 1) * w / 3, bottom_pos[row])
+                        lines = [i for i in page.get_drawings_in_bbox(bbox)
+                                 if np.isclose(i['rect'].y0, i['rect'].y1, atol=1)
+                                 and i['fill'] is None]
+                        assert len(lines) >= 1, \
+                            f'Expected at least one horizontal line for table(s) in row {row}, ' \
+                            f'col {col} in p.{page.number} in {self.lap_times_file}. Found none'
+                        assert np.allclose(
+                            [i['rect'].y0 for i in lines],
+                            lines[0]['rect'].y0,
+                            atol=1
+                        ), \
+                            f'Horizontal lines for table(s) in row {row}, col {col} on p.' \
+                            f'{page.number} in {self.lap_times_file} are not at the same y-coord.'
+
+                        # Concat lines.
+                        lines.sort(key=lambda x: x['rect'].x0)
+                        rect = lines[0]['rect']
+                        top_lines = [(rect.x0, rect.y0, rect.x1, rect.y1)]
+                        for line in lines[1:]:
+                            rect = line['rect']
+                            prev_line = top_lines[-1]
+                            # If one line ends where the other starts, they are the same line
+                            if np.isclose(rect.x0, prev_line[2], atol=1):
+                                top_lines[-1] = (prev_line[0], prev_line[1], rect.x1, prev_line[3])
+                            # If one line starts where the other ends, they are the same line
+                            elif np.isclose(rect.x1, prev_line[0], atol=1):
+                                top_lines[-1] = (rect.x0, prev_line[1], prev_line[2], prev_line[3])
+                            # Otherwise, it's a new line
+                            else:
+                                top_lines.append((rect.x0, rect.y0, rect.x1, rect.y1))
+                        assert len(top_lines) in [1, 2], \
+                            f'Expected at most two horizontal lines for table(s) in row {row}, ' \
+                            f'col. {col} on p.{page.number} in {self.lap_times_file}. Found ' \
+                            f'{len(top_lines)}'
+
+                        # Find the column separators
+                        col_seps = []
+                        for line in top_lines:
+                            lap = page.search_for('LAP',
+                                                  clip=(line[0], line[1] - 15, line[2], line[3]))
+                            assert len(lap) == 1, \
+                                f'Expected exactly one "LAP" above the top line at (' \
+                                f'{line[0], line[1], line[2], line[3]}) on p.{page.number} in ' \
+                                f'{self.lap_analysis_file}. Found {len(lap)}'
+                            col_seps.append([
+                                (line[0], lap[0].x1),
+                                (lap[0].x1, (line[0] + line[2]) / 2 - 5),
+                                ((line[0] + line[2]) / 2 - 5, line[2])
+                            ])
+
+                        # Find the white and grey rectangles under the top lines. Each row is either
+                        # coloured/filled in white or grey, so we can get the row's top and bottom
+                        # y-positions from these rectangles
+                        rects = [i for i in page.get_drawings_in_bbox(bbox)
+                                 if i['rect'].y1 - i['rect'].y0 > 10]
+                        ys = [j for i in rects for j in [i['rect'].y0, i['rect'].y1]]
+                        ys.sort()
+                        row_seps = [ys[0]]
+                        for y in ys[1:]:
+                            if y - row_seps[-1] > 10:
+                                row_seps.append(y)
+                        row_seps = [(row_seps[i], row_seps[i + 1])
+                                    for i in range(len(row_seps) - 1)]
+
+                        # Finally we are good to parse the tables using these separators
+                        temp = []
+                        for cols in col_seps:
+                            tab, superscript, cross_out = page.parse_table_by_grid(
+                                vlines=cols, hlines=row_seps
+                            )
+                            assert (len(superscript) == 0) and (len(cross_out) == 0), \
+                                f'Some superscript(s) or cross-out texts found in table at ' \
+                                f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
+                                f'{row_seps[-1][1]:.1f}) on p.{page.number} in ' \
+                                f'{self.lap_analysis_file}. But expect none'
+                            # Drop empty row
+                            tab = tab[tab[0] != '']
+                            temp.append(tab)
+
+                        # One driver may have multiple tables. Concatenate them
+                        temp = pd.concat(temp, ignore_index=True)
+                        temp['car_no'] = car_no
+                        temp['driver'] = driver
+                        temp.rename(columns={0: 'lap', 1: 'pit', 2: 'lap_time'}, inplace=True)
+                        df.append(temp)
+
         df = pd.concat(df, ignore_index=True)
         df.lap = df.lap.astype(int)
         df.pit = df.pit.apply(lambda x: x == 'P')

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -258,13 +258,17 @@ class RaceParser:
     def __init__(
             self,
             classification_file: str | os.PathLike,
+            lap_analysis_file: str | os.PathLike,
             history_chart_file: str | os.PathLike,
+            lap_chart_file: str | os.PathLike,
             year: int,
             round_no: int,
             session: Literal['race', 'sprint_race']
     ):
         self.classification_file = classification_file
+        self.lap_analysis_file = lap_analysis_file
         self.history_chart_file = history_chart_file
+        self.lap_chart_file = lap_chart_file
         self.session = session
         self.year = year
         self.round_no = round_no
@@ -508,13 +512,13 @@ class RaceParser:
         df.to_pkl = to_pkl
         return df
 
-    def _parse_lap_times(self) -> pd.DataFrame:
+    def _parse_history_chart(self) -> pd.DataFrame:
         doc = pymupdf.open(self.history_chart_file)
         df = []
         for page in doc:
             # Each page can have multiple tables, all of which begins from the same top y-position.
             # Their table headers are vertically bounded between "History Chart" and "TIME". Find
-            # all of the headers
+            # all the headers
             t = page.search_for('History Chart')[0].y1
             b = page.search_for('TIME')[0].y1
             w = page.bound()[2]
@@ -554,6 +558,7 @@ class RaceParser:
                 temp = temp[temp.car_no != '']  # Sometimes will get one additional empty row
 
                 # The row order/index is meaningful: it's the order/positions of the cars
+                # Need extra care for lapped cars; see harningle/fia-doc#19
                 # TODO: is this true for all cases? E.g. retirements?
                 temp.reset_index(drop=False, names=['position'], inplace=True)
                 temp['position'] += 1  # 1-indexed
@@ -608,16 +613,253 @@ class RaceParser:
 
         # TODO: Perez "retired and rejoined" in 2023 Japanese... Maybe just mechanically assign lap
         #       No. as 1, 2, 3, ... for each driver?
+        return df
+
+    def _parse_lap_chart(self) -> pd.DataFrame:
+        doc = pymupdf.open(self.lap_chart_file)
+        df = []
+        for page in doc:
+            t = page.search_for('Race Lap Chart')[0].y1  # The table is below "Race Lap Chart"
+            b = page.search_for('page')[0].y0            # The table is above "page x of y"
+
+            # Left boundary is the leftmost "LAP x"
+            l = page.search_for('LAP', clip=(0, t, page.bound()[2], b))[0].x0
+
+            # Top row's leftmost cell is "POS"
+            pos = page.search_for('POS', clip=(l, t, page.bound()[2], b))[0]
+            assert pos.x0 >= l, \
+                f'Expected "POS" to be (slightly) to the right of "LAP x" on page {page.number} ' \
+                f"in {self.lap_chart_file}. But it's found to the left"
+            assert pos.y0 > t, \
+                f'Expected "POS" below "Race Lap Chart" on page {page.number} in ' \
+                f'{self.lap_chart_file}. But it\'s found above'
+
+            # To the right of "POS", we have positions 1, 2, ...
+            positions = page.get_text('dict', clip=(pos.x1, pos.y0, page.bound()[2], pos.y1))
+            assert len(positions['blocks']) == 1, f'Error in parsing positions in top row on ' \
+                                        f'page {page.number} in {self.lap_chart_file}'
+            positions = positions['blocks'][0]['lines']
+            assert positions, \
+                f'Expected some positions to the right of "POS" on page {page.number} in ' \
+                f'{self.lap_chart_file}. Found none'
+
+            # Each position is a col., so we take the midpoints between two positions as the col.
+            # separators
+            col_seps = [l - 5, (pos.x1 + positions[0]['bbox'][0]) / 2]
+            for i in range(len(positions) - 1):
+                col_seps.append((positions[i]['bbox'][2] + positions[i + 1]['bbox'][0]) / 2)
+            col_seps.append(page.bound()[2])
+
+            # Below "POS" we have rows GRID, LAP 1, LAP 2, ...
+            laps = page.get_text('dict', clip=(l - 5, pos.y1, col_seps[1], b))
+            assert len(laps['blocks']) == 1, f'Error in parsing laps in leftmost col. on ' \
+                                             f'page {page.number} in {self.lap_chart_file}'
+            laps = laps['blocks'][0]['lines']
+            assert laps, \
+                f'Expected some laps below "POS" on page {page.number} in ' \
+                f'{self.lap_chart_file}. Found none'
+
+            # Each lap is a row, so we take the midpoints between two laps as the row separators
+            row_seps = [pos.y0 - 1, (pos.y1 + laps[0]['bbox'][1]) / 2]
+            for i in range(len(laps) - 1):
+                row_seps.append((laps[i]['bbox'][3] + laps[i + 1]['bbox'][1]) / 2)
+            row_seps.append(b)
+
+            # Parse the table
+            page = Page(page)
+            tab, superscript, cross_out = page.parse_table_by_grid(
+                vlines=[(col_seps[i], col_seps[i + 1]) for i in range(len(col_seps) - 1)],
+                hlines=[(row_seps[i], row_seps[i + 1]) for i in range(len(row_seps) - 1)]
+            )
+            assert (len(superscript) == 0) and len(cross_out) == 0, \
+                f'Some superscript(s) or crossed out text(s) found in table on page ' \
+                f'{page.number} in {self.lap_chart_file}. Expect none'
+            assert (len(superscript) == 0) and len(cross_out) == 0, \
+                f'Some superscript(s) or crossed out text(s) found in table on page ' \
+                f'{page.number} in {self.lap_chart_file}. Expect none'
+
+            # Reshape to long format, where a row is (lap, driver, position)
+            tab.columns = tab.iloc[0]
+            tab = tab[1:]
+            tab.index.name = None
+            tab = tab[tab.POS != 'GRID']  # TODO: should get starting grid here later
+            tab.POS = tab.POS.str.removeprefix('LAP ').astype(int)
+            tab = tab.set_index('POS').stack().reset_index(name='car_no')
+            tab.rename(columns={'POS': 'lap', 0: 'position'}, inplace=True)
+            tab = tab[tab.car_no != '']
+            tab.position = tab.position.astype(int)
+            tab.car_no = tab.car_no.astype(int)
+            df.append(tab)
+        return pd.concat(df, ignore_index=True)
+
+    def _parse_lap_analysis(self) -> pd.DataFrame:
+        doc = pymupdf.open(self.lap_analysis_file)
+        b, r = doc[0].bound()[3], doc[0].bound()[2]
+        df = []
+        for page in doc:
+            # Get the position of "LAP" and "TIME" on the page. Can have multiple of them, all of
+            # which should have approx. the same y-coord. The tables are below these texts
+            h = page.search_for('Race Lap Analysis')[0].y1
+            laps = page.search_for('LAP', clip=(0, h, r, b))
+            times = page.search_for('TIME', clip=(0, h, r, b))
+            assert len(laps) == len(times), \
+                f'#. of "LAP" and #. of "TIME" do not match on p.{page.number} in ' \
+                f'{self.lap_analysis_file}'
+            for i in range(len(laps) - 1):
+                assert np.isclose(laps[i].y1, laps[i + 1].y1, atol=1) and \
+                          np.isclose(times[i].y1, times[i + 1].y1, atol=1), \
+                    f'y-coord. of "LAP" and "TIME" do not match on p.{page.number} in ' \
+                    f'{self.lap_analysis_file}'
+
+            # Horizontally, three drivers share the full width of the page, side by side
+            # See QualifyingParser._parse_lap_times() for detailed explanation
+            w = r / 3
+            for i in range(3):
+                # Driver's name is below "Race Lap Analysis" and above the table
+                l = i * w
+                r = (i + 1) * w
+                t = min([i.y0 for i in laps] + [i.y0 for i in times])
+                driver = page.get_text('block', clip=(l, h, r, t)).strip()
+                if not driver:
+                    continue
+                    # TODO: may want a test here. Every row above should have exactly three drivers
+                car_no, driver = driver.split('\n', 1)
+
+                # Each driver has two tables side by side. We parse the tables by manually
+                # specifying row and col. positions (harningle/fia-doc#17)
+                # TODO: need to check if always have two tables. A good edge case is Spa 2021
+
+                # Find the horizontal lines under which the tables are located
+                page = Page(page)
+                t = max([i.y1 for i in laps] + [i.y1 for i in times])
+                lines = [i for i in page.get_drawings_in_bbox((l, t, r, t + 10))
+                         if np.isclose(i['rect'].y0, i['rect'].y1, atol=1)]
+                assert len(lines) >= 1, f'Expected at least one horizontal line for ' \
+                                        f'table(s) in col. {i} in page {page.number} in ' \
+                                        f'{self.history_chart_file}. Found none'
+                assert np.allclose([i['rect'].y0 for i in lines], lines[0]['rect'].y0, atol=1), \
+                    f'Horizontal lines for table(s) in col. {i} in page {page.number} in ' \
+                    f'{self.history_chart_file} are not at the same y-position'
+
+                # Concat lines.
+                lines.sort(key=lambda x: x['rect'].x0)
+                rect = lines[0]['rect']
+                top_lines = [(rect.x0, rect.y0, rect.x1, rect.y1)]
+                for line in lines[1:]:
+                    rect = line['rect']
+                    prev_line = top_lines[-1]
+                    # If one line ends where the other starts, they are the same line
+                    if np.isclose(rect.x0, prev_line[2], atol=1):
+                        top_lines[-1] = (prev_line[0], prev_line[1], rect.x1, prev_line[3])
+                    # If one line starts where the other ends, they are the same line
+                    elif np.isclose(rect.x1, prev_line[0], atol=1):
+                        top_lines[-1] = (rect.x0, prev_line[1], prev_line[2], prev_line[3])
+                    # Otherwise, it's a new line
+                    else:
+                        top_lines.append((rect.x0, rect.y0, rect.x1, rect.y1))
+                assert len(top_lines) in [1, 2], \
+                    f'Expected at most two horizontal lines for table(s) in col. {i} in page ' \
+                    f'{page.number} in {self.history_chart_file}. Found {len(top_lines)}'
+
+                # Find the column separators
+                col_seps = []
+                for line in top_lines:
+                    no = page.search_for('LAP', clip=(line[0], line[1] - 15, line[2], line[3]))
+                    assert len(no) == 1, \
+                        f'Expected exactly one "LAP" above the top line at ' \
+                        f'({line[0], line[1], line[2], line[3]}) in page {page.number} in ' \
+                        f'{self.history_chart_file}. Found {len(no)}'
+                    col_seps.append([
+                        (line[0], no[0].x1),
+                        (no[0].x1, (line[0] + line[2]) / 2 - 5),
+                        ((line[0] + line[2]) / 2 - 5, line[2])
+                    ])
+
+                # Find the white and grey rectangles under the top lines. Each row is either
+                # coloured/filled in either white or grey, so we can get the row's top and bottom
+                # y-positions from these rectangles
+                rects = [i for i in page.get_drawings_in_bbox((l, t, r, b))
+                         if i['rect'].y1 - i['rect'].y0 > 10]
+                ys = [j for i in rects for j in [i['rect'].y0, i['rect'].y1]]
+                ys.sort()
+                row_seps = [ys[0]]
+                for y in ys[1:]:
+                    if y - row_seps[-1] > 10:
+                        row_seps.append(y)
+                row_seps = [(row_seps[i], row_seps[i + 1]) for i in range(len(row_seps) - 1)]
+
+                # Finally we are good to parse the tables using these separators
+                temp = []
+                for cols in col_seps:
+                    tab, superscript, cross_out = page.parse_table_by_grid(
+                        vlines=cols, hlines=row_seps
+                    )
+                    assert (len(superscript) == 0) and len(cross_out) == 0, \
+                        f'Some superscript(s) or crossed out text(s) found in table at ' \
+                        f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
+                        f'{row_seps[-1][1]:.1f}) in page {page.number} in ' \
+                        f'{self.history_chart_file}. But we expect none'
+                    assert tab.shape[1] == 3, \
+                        f'Expected three columns (LAP, pit or not, lap time) in table at ' \
+                        f'({cols[0][0]:.1f}, {row_seps[0][0]:.1f}, {cols[2][1]:.1f}, ' \
+                        f'{row_seps[-1][1]:.1f}) in page {page.number} in ' \
+                        f'{self.history_chart_file}. Found {len(tab)}'
+                    tab.columns = ['lap', 'pit', 'lap_time']
+
+                    # Drop empty row
+                    """
+                    This is because the two side-by-side tables may not have the same amount of
+                    rows. E.g., there are 11 laps, and the left table will have 6 and the right
+                    table has 5 rows. The right table will have an empty row at the bottom, so
+                    drop it here
+                    """
+                    tab = tab[tab.lap != '']
+                    temp.append(tab)
+
+                # One driver may have multiple tables. Concatenate them
+                temp = pd.concat(temp, ignore_index=True)
+                temp['car_no'] = car_no
+                temp['driver'] = driver
+                df.append(temp)
+        df = pd.concat(df, ignore_index=True)
+        df.lap = df.lap.astype(int)
+        df.pit = df.pit.apply(lambda x: x == 'P')
+        df.car_no = df.car_no.astype(int)
+        return df
+
+    def _parse_lap_times(self) -> pd.DataFrame:
+        # Get lap times from Race Lap Analysis PDF
+        df = self._parse_lap_analysis()
+
+        # Lap 1's lap times are calendar time in Race Lap Analysis. To get the actual lap time for
+        # lap 2, we parse Race History Chart PDF
+        lap_1 = self._parse_history_chart()
+        lap_1 = lap_1[lap_1.lap == 1][['car_no', 'lap', 'time']]
+        df = df.merge(lap_1, on=['car_no', 'lap'], how='outer', indicator=True, validate='1:1')
+        assert (df[df.lap == 1]['_merge'] == 'both').all(), \
+            f"Lap 1's data do not match in {self.lap_analysis_file} and {self.history_chart_file}"
+        df.loc[df.lap == 1, 'lap_time'] = df.loc[df.lap == 1, 'time']
+        del df['time'], df['_merge'], lap_1
+
+        # Merge in car positions from Race Lap Chart PDF
+        positions = self._parse_lap_chart()
+        df = df.merge(positions, on=['car_no', 'lap'], how='outer', indicator=True, validate='1:1')
+        assert (df._merge == 'both').all(), f'Some laps only found in only one of ' \
+                                            f'{self.lap_analysis_file} and {self.lap_chart_file}'
+        del df['_merge'], positions
 
         # Merge in the fastest lap info. from final classification
         df = df.merge(self.classification_df[['car_no', 'fastest_lap_time', 'fastest_lap_no']],
-                      on='car_no',
-                      how='left')
+                      on='car_no', how='outer', indicator=True, validate='m:1')
+        assert (df._merge == 'both').all(), \
+            f'Some drivers only found in only one of {self.lap_analysis_file} and ' \
+            f'{self.classification_file}'  # TODO: is this always true? Crash before setting a lap?
+        del df['_merge']
         temp = df[df.lap == df.fastest_lap_no]
-        assert (temp.time == temp.fastest_lap_time).all(), \
+        assert (temp.lap_time == temp.fastest_lap_time).all(), \
             'Fastest lap time in lap times does not match the one in final classification'
         df['is_fastest_lap'] = df.lap == df.fastest_lap_no
-        del df['fastest_lap_time']
+        del df['fastest_lap_time'], df['fastest_lap_no']
 
         def to_json() -> list[dict]:
             temp = df.copy()
@@ -625,7 +867,7 @@ class RaceParser:
                 lambda x: Lap(
                     number=x.lap,
                     position=x.position,
-                    time=duration_to_millisecond(x.time),
+                    time=duration_to_millisecond(x.lap_time),
                     is_entry_fastest_lap=x.is_fastest_lap
                 ),
                 axis=1
@@ -744,7 +986,8 @@ class QualifyingParser:
         aux_lines = sorted(set([round(i[0], 2) for i in df[0].cells]))  # For unclassified table
         df = df[0].to_pandas()
         # TODO: check 2023 vs 2024 PDF. Do we have a "%" col.? 15 or 14 col. in total?
-        assert df.shape[1] == 14, \
+        assert ((df.shape[1] == 14) and self.year == 2024) \
+               or ((df.shape[1] == 15) and (self.year == 2023)), \
             f'Expected 15 columns, got {df.shape[1]} in {self.classification_file}'
 
         # Clean up column name: the first row is mistakenly taken as column names
@@ -760,10 +1003,18 @@ class QualifyingParser:
         cols = df.columns.tolist()
         for i in range(len(df.columns)):
             cols[i] = df.columns[i].removeprefix(f'{i}-')
+        match self.year:
+            case 2024:
+                columns = ['position', 'NO', 'DRIVER', 'NAT', 'ENTRANT', 'Q1', 'Q1_LAPS',
+                           'Q1_TIME', 'Q2', 'Q2_LAPS', 'Q2_TIME', 'Q3', 'Q3_LAPS', 'Q3_TIME']
+            case 2023:
+                columns = ['position', 'NO', 'DRIVER', 'NAT', 'ENTRANT', 'Q1', 'Q1_LAPS', 'Q1_%',
+                           'Q1_TIME', 'Q2', 'Q2_LAPS', 'Q2_TIME', 'Q3', 'Q3_LAPS', 'Q3_TIME']
+            case _:
+                raise ValueError(f'PDFs from year {self.year} are not supported')
         df = pd.DataFrame(
             np.vstack([cols, df]),
-            columns=['position', 'NO', 'DRIVER', 'NAT', 'ENTRANT', 'Q1', 'Q1_LAPS', 'Q1_TIME',
-                     'Q2', 'Q2_LAPS', 'Q2_TIME', 'Q3', 'Q3_LAPS', 'Q3_TIME']
+            columns=columns
         )
         df = df[(df.NO != '') | df.NO.isnull()]  # May get some empty rows at the bottom. Drop them
         df['finishing_status'] = 0

--- a/fiadoc/tests/fixtures/2023_18_quali_classification.json
+++ b/fiadoc/tests/fixtures/2023_18_quali_classification.json
@@ -1,0 +1,632 @@
+[
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "position": 1
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "position": 2
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "position": 3
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "position": 4
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "position": 5
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "position": 6
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "position": 7
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "position": 8
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "position": 9
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "position": 10
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "position": 11
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "position": 12
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "position": 13
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "position": 14
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "position": 15
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "position": 16
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "position": 17
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "position": 18
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "position": 19
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "position": 20
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "position": 1
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "position": 2
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "position": 3
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "position": 4
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "position": 5
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "position": 6
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "position": 7
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "position": 8
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "position": 9
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "position": 10
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "position": 11
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "position": 12
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "position": 13
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "position": 14
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "position": 15
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "position": 1
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "position": 2
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "position": 3
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "position": 4
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "position": 5
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "position": 6
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "position": 7
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "position": 8
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "position": 9
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "position": 10
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2023_18_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_quali_lap_times.json
@@ -1,0 +1,1859 @@
+[
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96622
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 114775
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96119
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 130027
+                }
+            },
+            {
+                "number": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 135621
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96061
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 130184
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95888
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 111061
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95004
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 131372
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94829
+                }
+            },
+            {
+                "number": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 112917
+                }
+            },
+            {
+                "number": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94723
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 21,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 128505
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97247
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 116152
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95824
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 129585
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96245
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125522
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95302
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 126963
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95174
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125341
+                }
+            },
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94945
+                }
+            },
+            {
+                "number": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 132332
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96470
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110722
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95346
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121084
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95491
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107896
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95008
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 119404
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95081
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 112741
+                }
+            },
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94718
+                }
+            },
+            {
+                "number": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 118718
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97222
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120439
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96213
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125339
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95974
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 115209
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96437
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 117118
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96680
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125152
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95989
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 132699
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95679
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124112
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121272
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "number": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95524
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 114808
+                }
+            },
+            {
+                "number": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95173
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96742
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 117263
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95091
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125884
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95779
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 119190
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95240
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121101
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94885
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 108508
+                }
+            },
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94862
+                }
+            },
+            {
+                "number": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122073
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96831
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 128254
+                }
+            },
+            {
+                "number": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 134270
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96671
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110614
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96064
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 119614
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95576
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121800
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 127657
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "number": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95761
+                }
+            },
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 117895
+                }
+            },
+            {
+                "number": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95467
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96625
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 133382
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96165
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 133022
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95759
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 129428
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95606
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 127751
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95682
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 112099
+                }
+            },
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95079
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96843
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 129337
+                }
+            },
+            {
+                "number": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 130421
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96952
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 116403
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96082
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 126466
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95946
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125717
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95858
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 130291
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97293
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 129616
+                }
+            },
+            {
+                "number": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 130449
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97525
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 114905
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96052
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 119046
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96115
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 130387
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95698
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 128588
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97529
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 111123
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96158
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122537
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95621
+                }
+            },
+            {
+                "number": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125256
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95496
+                }
+            },
+            {
+                "number": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 126098
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95267
+                }
+            },
+            {
+                "number": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121584
+                }
+            },
+            {
+                "number": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95089
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96235
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 114289
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96379
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 117834
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97032
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 148774
+                }
+            },
+            {
+                "number": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96866
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 115558
+                }
+            },
+            {
+                "number": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96268
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 127631
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96993
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 115504
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96315
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124586
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96915
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 115234
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95913
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124796
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95790
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 112865
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95697
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 127855
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97542
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120473
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96561
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120142
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96131
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124289
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95600
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124121
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95413
+                }
+            },
+            {
+                "number": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122803
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95960
+                }
+            },
+            {
+                "number": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121553
+                }
+            },
+            {
+                "number": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95154
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97138
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 109734
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96009
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122262
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96001
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 116345
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95880
+                }
+            },
+            {
+                "number": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123242
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98515
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 114344
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96624
+                }
+            },
+            {
+                "number": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 118359
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96589
+                }
+            },
+            {
+                "number": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125986
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96640
+                }
+            },
+            {
+                "number": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 128974
+                }
+            },
+            {
+                "number": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 133569
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101688
+                }
+            },
+            {
+                "number": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95110
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122794
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q2",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "number": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95981
+                }
+            },
+            {
+                "number": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124578
+                }
+            },
+            {
+                "number": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95441
+                }
+            },
+            {
+                "number": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 128533
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q3",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "number": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 95705
+                }
+            },
+            {
+                "number": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 112360
+                }
+            },
+            {
+                "number": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 94853
+                }
+            },
+            {
+                "number": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123618
+                }
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "Q1",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "number": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101362
+                }
+            },
+            {
+                "number": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98203
+                }
+            },
+            {
+                "number": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107924
+                }
+            },
+            {
+                "number": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96827
+                }
+            },
+            {
+                "number": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121401
+                }
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2023_18_race_classification.json
+++ b/fiadoc/tests/fixtures/2023_18_race_classification.json
@@ -1,0 +1,462 @@
+[
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "position": 1,
+                "is_classified": true,
+                "status": 0,
+                "points": 25,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5721362
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 9
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "position": 2,
+                "is_classified": true,
+                "status": 0,
+                "points": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5732092
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 8
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "position": 3,
+                "is_classified": true,
+                "status": 0,
+                "points": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5736496
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 10
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "position": 4,
+                "is_classified": true,
+                "status": 0,
+                "points": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5739822
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 5
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "position": 5,
+                "is_classified": true,
+                "status": 0,
+                "points": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5746361
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 3
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "position": 6,
+                "is_classified": true,
+                "status": 0,
+                "points": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5769358
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 11
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "position": 7,
+                "is_classified": true,
+                "status": 0,
+                "points": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5770058
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 6
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "position": 8,
+                "is_classified": true,
+                "status": 0,
+                "points": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5795747
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 1
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "position": 9,
+                "is_classified": true,
+                "status": 0,
+                "points": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5808076
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 15
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "position": 10,
+                "is_classified": true,
+                "status": 0,
+                "points": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5809360
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 14
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "position": 11,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5811266
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 12
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "position": 12,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5819963
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 18
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "position": 13,
+                "is_classified": true,
+                "status": 1,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5724938
+                },
+                "laps_completed": 55,
+                "fastest_lap_rank": 17
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "position": 14,
+                "is_classified": true,
+                "status": 1,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5729434
+                },
+                "laps_completed": 55,
+                "fastest_lap_rank": 16
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "position": 15,
+                "is_classified": true,
+                "status": 1,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5730214
+                },
+                "laps_completed": 55,
+                "fastest_lap_rank": 2
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "position": 16,
+                "is_classified": false,
+                "status": 11,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5078227
+                },
+                "laps_completed": 49,
+                "fastest_lap_rank": 7
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "position": 17,
+                "is_classified": false,
+                "status": 11,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1059564
+                },
+                "laps_completed": 10,
+                "fastest_lap_rank": 19
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "position": 18,
+                "is_classified": false,
+                "status": 11,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 648449
+                },
+                "laps_completed": 6,
+                "fastest_lap_rank": 20
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "position": 19,
+                "is_classified": true,
+                "status": 20,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5723587
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 4
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "position": 20,
+                "is_classified": true,
+                "status": 20,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5746024
+                },
+                "laps_completed": 56,
+                "fastest_lap_rank": 13
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2023_18_race_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_race_lap_times.json
@@ -1,0 +1,9348 @@
+[
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105537
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103009
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102700
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102623
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102151
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102857
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102817
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102598
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102969
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102741
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103147
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102515
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102569
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102334
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102654
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102571
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120701
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100989
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100809
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100883
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100980
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101129
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100921
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101203
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101268
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101857
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101795
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101574
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101592
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101658
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101337
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101576
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101507
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101581
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101777
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122166
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100763
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100439
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100124
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100028
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 41,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100449
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100349
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100212
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100770
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100245
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100588
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100310
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100329
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100418
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100209
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100099
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100335
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100636
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100629
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100998
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100337
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101712
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101982
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102280
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102331
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102244
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102802
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102742
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102500
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102667
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102391
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102426
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102113
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103071
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102792
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102557
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102725
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102594
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121475
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101366
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101192
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101262
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101388
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100970
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102405
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102115
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101830
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103150
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102008
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101493
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101560
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102211
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102812
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102130
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101438
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100684
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100025
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99985
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 40,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100437
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100733
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100635
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100714
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100616
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101107
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101166
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101222
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102748
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100838
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101004
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100682
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100904
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100884
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101084
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104398
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102659
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102583
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103432
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103744
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102882
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102950
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102609
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102910
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103597
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102880
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103454
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103065
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103652
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103418
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121500
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100667
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101197
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101647
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101683
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101539
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101490
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101825
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101479
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101735
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101462
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101484
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101584
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101550
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101888
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101677
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102067
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120188
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100575
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100294
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100839
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100578
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100907
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100665
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100724
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100885
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100716
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100653
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100872
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100579
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100323
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100034
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 52,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100593
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100563
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100877
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101328
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101178
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 108071
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104884
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103862
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102527
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102849
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102894
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103505
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103419
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103070
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102676
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102473
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103051
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102695
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103188
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102992
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103567
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121339
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101399
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101335
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101501
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101292
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101403
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101445
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101166
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101790
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101164
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101214
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101280
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101378
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101804
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102000
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101238
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101706
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101790
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101956
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121015
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99881
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99737
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 41,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100837
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100763
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101046
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101277
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100684
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100727
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100759
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100528
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100319
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100129
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100268
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101107
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100380
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100956
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101059
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107629
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104818
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103473
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101994
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102394
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102814
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102701
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103380
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103062
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102655
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103172
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102559
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102820
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103111
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103409
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102932
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103082
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102655
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103038
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103378
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104164
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122793
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101437
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101943
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101867
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101574
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102729
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101930
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102299
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102097
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102128
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102071
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102065
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102533
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102200
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 119773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99738
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100116
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99926
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99809
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99845
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99987
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99910
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99393
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 49,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99673
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99676
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99577
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100521
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100179
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100340
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100794
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 108429
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104960
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105491
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102408
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102636
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102777
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102687
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103140
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103407
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102699
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103459
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103424
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103120
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103212
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103443
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103920
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120632
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101882
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101963
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102598
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101948
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102035
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102335
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102323
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102201
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102465
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102102
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102368
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102516
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102237
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102178
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101983
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102052
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122732
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101934
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101134
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100979
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101109
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101271
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101363
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100695
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101024
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100412
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 48,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100668
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100641
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100713
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101168
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101123
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101115
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100963
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101087
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101399
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 114949
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104567
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104207
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105660
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104919
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103424
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103864
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104014
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103852
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104246
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103411
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103003
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103343
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103150
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103510
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103148
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103581
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104135
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103523
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103805
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122975
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101825
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102290
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102367
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102034
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102273
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103576
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101595
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101447
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101401
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101479
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101469
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101680
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101538
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101615
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101631
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101614
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101361
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101276
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 119410
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100544
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100783
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100259
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100038
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100350
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99971
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99908
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 49,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100176
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99984
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100224
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100530
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100372
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100636
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100343
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100842
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 109255
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104820
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105158
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103281
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103084
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103266
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103314
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103392
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103425
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103232
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103284
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103007
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103428
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103486
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103434
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103601
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103535
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122297
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102014
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102118
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101942
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102485
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102226
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102292
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102341
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102942
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102666
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102588
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102243
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102475
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102427
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102500
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102676
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121787
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101710
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101477
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101832
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101782
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101439
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101316
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101545
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101327
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102652
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101392
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101050
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101954
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102640
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100909
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100632
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100603
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100695
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100562
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101299
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122300
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98139
+                },
+                "is_entry_fastest_lap": true
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110368
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105576
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104644
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104873
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103803
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103814
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104006
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103728
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123675
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103292
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103267
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103164
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103092
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103131
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103080
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103007
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103069
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103029
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102679
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103298
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103861
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103614
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103618
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103218
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102855
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103006
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102913
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122861
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101927
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102270
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102105
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102021
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101861
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102009
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101765
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101441
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101732
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101371
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102367
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101573
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102202
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101857
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101517
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101764
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101675
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101318
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 49,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101596
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101386
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102060
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102909
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102483
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102762
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103001
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102791
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 111967
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105391
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104757
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105423
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103736
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103644
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104940
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104280
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103724
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104188
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103570
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124136
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103183
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103099
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102693
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103071
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102460
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102481
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102777
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103214
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103732
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103454
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103234
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103950
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104066
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103400
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102904
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103039
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103683
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103953
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123196
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101238
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 35,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101630
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101541
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101838
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101570
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101497
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101289
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101432
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101665
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101806
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101574
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101969
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102036
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102097
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101953
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101555
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101626
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101916
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101948
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103008
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101823
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102494
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102508
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 113245
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105269
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104800
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105723
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104648
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104916
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103802
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104130
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104266
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104643
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103408
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103771
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103671
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103483
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103572
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103469
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103335
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 125273
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102602
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101964
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102190
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102003
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102265
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102329
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102840
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102740
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101874
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101682
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102446
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103145
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102889
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121785
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101458
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101014
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101154
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101108
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102036
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101736
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101845
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102412
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100925
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 46,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101864
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101919
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101654
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101614
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102462
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103840
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102650
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102450
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102927
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110847
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105494
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104704
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105328
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103389
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103722
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103915
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103987
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103664
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104078
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123570
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103069
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103173
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103094
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103224
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103016
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102603
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103009
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103406
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102849
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102902
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103844
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103611
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103731
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103735
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103455
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103400
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104289
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123100
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102281
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102332
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102355
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102655
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102736
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102580
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102454
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103227
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103604
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102520
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102426
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102342
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102685
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102282
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102311
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102539
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102395
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102446
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102228
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102169
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102080
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102308
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102058
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102156
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101972
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 55,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102918
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103696
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 108931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105658
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105043
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104264
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103624
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103322
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103606
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103615
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103882
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124238
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102787
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102810
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103560
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103450
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103345
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103132
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103244
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103132
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103172
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102845
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103142
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103657
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103809
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103917
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105000
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103690
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107714
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124070
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102946
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103042
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102846
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102223
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102941
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103772
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103288
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102713
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103111
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102219
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102301
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102085
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102158
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102816
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102886
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102450
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102113
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102503
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102106
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102051
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101927
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101879
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 52,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102158
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102493
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102441
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105880
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 111572
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105395
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104642
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105433
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103618
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103521
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103874
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104096
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103824
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104749
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 124946
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103658
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104629
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103941
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103867
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103726
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103225
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102918
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103133
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103105
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104551
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103838
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103784
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104564
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103893
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103862
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103822
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103913
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104007
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123839
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102909
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102031
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102070
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102159
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102115
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102669
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102553
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102428
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102296
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102313
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101506
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 42,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101547
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102509
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102293
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102161
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102281
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101732
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101616
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102208
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102139
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102395
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107413
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103838
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 109807
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105228
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105061
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104687
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103556
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103464
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103709
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103820
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103635
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103451
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103117
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103126
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103335
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103399
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103363
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103154
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104120
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103489
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103305
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104525
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105321
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104235
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123516
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102542
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103560
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103547
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104336
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103403
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103870
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103435
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103198
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103386
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102895
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103361
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103083
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103026
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102456
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102351
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102567
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103395
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104394
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103490
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104791
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103429
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103929
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 126471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99366
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 50,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100658
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100202
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103236
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101577
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101431
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102458
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 112441
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105424
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104736
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 105467
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103792
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103668
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103581
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103679
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103775
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104591
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102559
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103108
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103334
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102790
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103818
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104156
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103648
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122272
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100987
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101588
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101490
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102185
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101830
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101817
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101657
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101658
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101669
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102061
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101893
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101561
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101890
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101329
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101905
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101359
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101419
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101376
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101637
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102303
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 121406
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100839
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100376
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100443
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99954
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 48,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 108118
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 106528
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 106169
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103799
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102929
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102820
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102705
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 6,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102837
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103325
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103427
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103263
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 128290
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107310
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104789
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 3,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 106421
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110009
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 108938
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110982
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104701
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102916
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102475
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102110
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102210
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102189
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102686
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102423
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102323
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102307
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101879
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102580
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102541
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102616
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102540
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102462
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102787
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103523
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 123034
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101729
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101227
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101074
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101173
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101486
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101154
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101506
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101533
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101310
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101844
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101980
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101225
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101199
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101307
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102192
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 120679
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99898
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99856
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99582
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 43,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100258
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100445
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100277
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100264
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99972
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100573
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100127
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99901
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99819
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100243
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99737
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99938
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100743
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "R",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103482
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102619
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102319
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102538
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102805
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103612
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103149
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103163
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102757
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103030
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 104450
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102762
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102762
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102771
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102831
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102801
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102530
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102717
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103074
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103200
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103366
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103617
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103570
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 122894
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102103
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102055
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101398
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101397
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101386
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101750
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101715
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101721
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101329
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101328
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101273
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101501
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101101
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101025
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 39,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102800
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101190
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101652
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101410
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102150
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101422
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101305
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101248
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101250
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101400
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102085
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101064
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102190
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102656
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101882
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102519
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102725
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2023_18_sprint_classification.json
+++ b/fiadoc/tests/fixtures/2023_18_sprint_classification.json
@@ -1,0 +1,462 @@
+[
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "position": 1,
+                "is_classified": true,
+                "status": 0,
+                "points": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1890849
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 1
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "position": 2,
+                "is_classified": true,
+                "status": 0,
+                "points": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1900314
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 2
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "position": 3,
+                "is_classified": true,
+                "status": 0,
+                "points": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1908836
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 3
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "position": 4,
+                "is_classified": true,
+                "status": 0,
+                "points": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1909712
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 4
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "position": 5,
+                "is_classified": true,
+                "status": 0,
+                "points": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1913777
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 5
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "position": 6,
+                "is_classified": true,
+                "status": 0,
+                "points": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1919156
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 8
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "position": 7,
+                "is_classified": true,
+                "status": 0,
+                "points": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1923252
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 7
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "position": 8,
+                "is_classified": true,
+                "status": 0,
+                "points": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1925099
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 9
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "position": 9,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1925416
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 6
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "position": 10,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1933252
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 14
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "position": 11,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1935835
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 13
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "position": 12,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1936358
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 10
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "position": 13,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1939935
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 12
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "position": 14,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1940582
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 11
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "position": 15,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1947499
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 15
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "position": 16,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1955250
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 17
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "position": 17,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1958821
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 18
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "position": 18,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1961971
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 19
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "position": 19,
+                "is_classified": true,
+                "status": 0,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1962298
+                },
+                "laps_completed": 19,
+                "fastest_lap_rank": 20
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "position": 20,
+                "is_classified": false,
+                "status": 11,
+                "points": 0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 1645131
+                },
+                "laps_completed": 16,
+                "fastest_lap_rank": 16
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2023_18_sprint_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_sprint_lap_times.json
@@ -1,0 +1,3435 @@
+[
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99060
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 3,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99459
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99349
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99227
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99387
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99706
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99726
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99769
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99683
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99640
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99730
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99632
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99405
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99392
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99367
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99817
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99181
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99391
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100198
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99634
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 4,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99852
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99669
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99921
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100119
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100089
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100280
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100209
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100230
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100321
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100612
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100015
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100478
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100915
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101006
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101269
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101621
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99448
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99138
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 4,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99344
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99433
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100060
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100330
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99864
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100148
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100199
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100043
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100208
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99779
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99873
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100004
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100170
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100320
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100395
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100843
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101075
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100560
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100135
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100293
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100333
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101135
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100557
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100767
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100058
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100030
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99887
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99982
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100027
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99795
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 16,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100042
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100008
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100309
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100492
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101815
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102870
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101510
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102308
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102360
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102072
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101517
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101108
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101247
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101335
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101284
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101414
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101289
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101210
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101037
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 17,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101272
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101056
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101748
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100911
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100627
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100262
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100223
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 6,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100428
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100889
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100856
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100845
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101673
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101846
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101173
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101290
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101425
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100515
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100671
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100708
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100705
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100708
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101841
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100693
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100308
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100252
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99824
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 7,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100408
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100601
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100625
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100818
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100321
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100555
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100058
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100265
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100081
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100300
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100705
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100358
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100466
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101979
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101753
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101807
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101737
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101211
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101185
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101495
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101508
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101043
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101188
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101275
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100842
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100779
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100407
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100175
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100094
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 18,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100194
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100067
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101720
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101995
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101525
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100155
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 6,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100777
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100566
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100457
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101027
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100537
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100648
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100541
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100576
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101121
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101320
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100999
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101399
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100829
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100828
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101958
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101903
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101832
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101636
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101843
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101954
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101664
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102553
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102216
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101491
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101574
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100434
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 15,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100840
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101125
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101280
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101079
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101790
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101632
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101327
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100578
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100451
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100477
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100530
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100571
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100857
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100253
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 11,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100444
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100713
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101120
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101629
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100484
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101006
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100567
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100794
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100851
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102601
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101782
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101863
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101538
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102340
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101681
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101015
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101545
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101880
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101646
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101715
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101273
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101025
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100853
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100805
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 17,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102479
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102256
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101904
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101915
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101776
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101695
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101718
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102030
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101526
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101443
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101503
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101616
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101549
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101602
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101298
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101013
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 16,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101127
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101554
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101410
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101871
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101813
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101789
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101809
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101460
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 6,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101886
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101993
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101716
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101487
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102007
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101552
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101614
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101564
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103544
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101803
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 110353
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103134
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102148
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101889
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102222
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102669
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102939
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103213
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103150
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102935
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103675
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102116
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101885
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101661
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102063
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101707
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101595
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 19,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101848
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102595
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101985
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101841
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101747
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102589
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101980
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101992
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102206
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102425
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102220
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103443
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101943
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101757
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101850
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101813
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101996
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101232
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 19,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101428
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102130
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101699
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 4,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102100
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101819
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103290
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103529
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103169
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103075
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103102
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103371
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103970
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103261
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102932
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102639
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103034
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103180
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102767
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103322
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102127
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101754
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102079
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101882
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102912
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102845
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103345
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103084
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102975
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103845
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102932
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101891
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102028
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101680
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101825
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101503
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 19,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101739
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102804
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102037
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101748
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101853
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102508
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102677
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103279
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101974
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101592
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101441
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101054
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100968
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101047
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100973
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101037
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100632
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 18,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100982
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101253
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2023,
+            "round": 18,
+            "session": "SR",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "number": 2,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103632
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102069
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102044
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102049
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101947
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 7,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102461
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102904
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103309
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102891
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102995
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103815
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102997
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102716
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103015
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102624
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102952
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 103294
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102557
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/test_parse_quali.py
+++ b/fiadoc/tests/test_parse_quali.py
@@ -13,6 +13,14 @@ race_list = [
         22,
         '2024_22_quali_provisional_classification.json',
         '2024_22_quali_lap_times.json'
+    ),
+    (
+        'doc_20_-_2023_united_states_grand_prix_-_final_qualifying_classification.pdf',
+        '2023_19_usa_f1_q0_timing_qualifyingsessionlaptimes_v01.pdf',
+        2023,
+        18,
+        '2023_18_quali_classification.json',
+        '2023_18_quali_lap_times.json'
     )
 ]
 

--- a/fiadoc/tests/test_parse_race.py
+++ b/fiadoc/tests/test_parse_race.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from fiadoc.parser import RaceParser
+from fiadoc.utils import download_pdf
+
+race_list = [
+    (
+        'doc_66_-_2023_united_states_grand_prix_-_final_race_classification.pdf',
+        '2023_19_usa_f1_r0_timing_racelapanalysis_v01.pdf',
+        '2023_19_usa_f1_r0_timing_racehistorychart_v01.pdf',
+        '2023_19_usa_f1_r0_timing_racelapchart_v01.pdf',
+        2023,
+        18,
+        '2023_18_race_classification.json',
+        '2023_18_race_lap_times.json'
+    )
+]
+
+
+@pytest.fixture(params=race_list)
+def prepare_race_data(request, tmp_path) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
+    # Download and parse race classification and lap times PDFs
+    url_classification, url_lap_analysis, url_history_chart, url_lap_chart, year, round_no, \
+        expected_classification, expected_lap_times = request.param
+    download_pdf('https://www.fia.com/sites/default/files/' + url_classification,
+                 tmp_path / 'classification.pdf')
+    download_pdf('https://www.fia.com/sites/default/files/' + url_lap_analysis,
+                 tmp_path / 'lap_analysis.pdf')
+    download_pdf('https://www.fia.com/sites/default/files/' + url_history_chart,
+                 tmp_path / 'history_chart.pdf')
+    download_pdf('https://www.fia.com/sites/default/files/' + url_lap_chart,
+                 tmp_path / 'lap_chart.pdf')
+    parser = RaceParser(tmp_path / 'classification.pdf', tmp_path / 'lap_analysis.pdf',
+                        tmp_path / 'history_chart.pdf', tmp_path / 'lap_chart.pdf',
+                        year, round_no, 'race')
+
+    classification_data = parser.classification_df.to_json()
+    lap_times_data = parser.lap_times_df.to_json()
+    with open('fiadoc/tests/fixtures/' + expected_classification, encoding='utf-8') as f:
+        expected_classification = json.load(f)
+    with open('fiadoc/tests/fixtures/' + expected_lap_times, encoding='utf-8') as f:
+        expected_lap_times = json.load(f)
+
+    # Sort data
+    classification_data.sort(key=lambda x: x['foreign_keys']['car_number'])
+    expected_classification.sort(key=lambda x: x['foreign_keys']['car_number'])
+    lap_times_data.sort(key=lambda x: x['foreign_keys']['car_number'])
+    expected_lap_times.sort(key=lambda x: x['foreign_keys']['car_number'])
+    for i in lap_times_data:
+        i['objects'].sort(key=lambda x: x['number'])
+    for i in expected_lap_times:
+        i['objects'].sort(key=lambda x: x['number'])
+
+    # TODO: currently manually tested against fastf1 lap times. The test data should be generated
+    #       automatically later. Also need to manually add if the lap time is deleted and if the
+    #       lap is fastest manually. Also need to add the laps where PDFs have data but fastf1
+    #       doesn't
+    return classification_data, lap_times_data, expected_classification, expected_lap_times
+
+
+def test_parse_race(prepare_race_data):
+    classification_data, lap_times_data, expected_classification, expected_lap_times \
+        = prepare_race_data
+    assert classification_data == expected_classification
+    assert lap_times_data == expected_lap_times

--- a/fiadoc/utils.py
+++ b/fiadoc/utils.py
@@ -172,12 +172,8 @@ class Page:
         3. a list of tuples for the superscript for a cell (i, j), in the format of
            (i, j, superscript text)
 
-        :param vlines: x-coords. of vertical lines separating the cols. The table left and right
-                       need to be included in this list. The i-th element is the left and right
-                       x-coords. of the i-th column
-        :param hlines: y-coords. of horizontal lines separating the rows. The table top and bottom
-                       need to be included in this list. The i-th element is the top and bottom
-                       y-coords. of the i-th row
+        :param vlines: List of left and right x-coords. of the cols
+        :param hlines: List of top and bottom y-coords. of the rows
         :return: A usual df., a list of superscript cells, a list of crossed out cells
         """
         cells = []


### PR DESCRIPTION
This fixed #19

It's very hard to determine the lap of cars from Race History Chart PDF. The PDF ranks cars by their absolute positions. That is, if car A is physically in front of B, A is ranked above B, regardless of whether B is lapped by A or not. When we have both lapped cars and cars in pit, it's hard to tell if a car is lapped, and thus we cannot assign the correct lap No. to lap time (Probably we can, but I wasn't able to find an easy way to do this.)

So I now use Race Lap Analysis as the source for lap time data. This PDF explicitly gives the lap No. of cars so no need to determine if a car is lapped. However, no position data is available in this PDF, nor lap 1's lap time data.

So we further use Race Lap Chart PDF to get the car positions, and get lap 1's lap times from Race History Chart