### PR TITLE
ensure that is_classified column always exists

### DIFF
--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -372,7 +372,6 @@ class RaceParser:
         df = df[(df.NO != '') | df.NO.isnull()]  # May get some empty rows at the bottom. Drop them
         assert df.shape[1] == 13, \
             f'Expected 13 columns, got {df.shape[1]} in {self.classification_file}'
-        df['is_classified'] = True  # Set all drivers from the main table as classified
 
         # Do the same for the "NOT CLASSIFIED" table
         if has_not_classified:
@@ -404,9 +403,17 @@ class RaceParser:
                 f'{not_classified.shape[1]} in {self.classification_file}'
             not_classified.columns = df.columns
             not_classified = not_classified[(not_classified.NO != '') | not_classified.NO.isnull()]
-            not_classified['finishing_status'] = 11  # TODO: should clean up the code later
-            not_classified['is_classified'] = False
-            df = pd.concat([df, not_classified], ignore_index=True)
+
+        else:
+            # no unclassified drivers
+            not_classified = pd.DataFrame(columns=df.columns)
+
+        df['is_classified'] = True # Set all drivers from the main table as classified
+
+        not_classified['finishing_status'] = 11  # TODO: should clean up the code later
+        not_classified['is_classified'] = False
+
+        df = pd.concat([df, not_classified], ignore_index=True)
 
         # Set col. names
         del df['NAT']

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -372,6 +372,7 @@ class RaceParser:
         df = df[(df.NO != '') | df.NO.isnull()]  # May get some empty rows at the bottom. Drop them
         assert df.shape[1] == 13, \
             f'Expected 13 columns, got {df.shape[1]} in {self.classification_file}'
+        df['is_classified'] = True  # Set all drivers from the main table as classified
 
         # Do the same for the "NOT CLASSIFIED" table
         if has_not_classified:
@@ -478,7 +479,6 @@ class RaceParser:
 
         # Fill in some default values
         df.fillna({
-            'is_classified': True,
             'points': 0,
             'finishing_status': 0
         }, inplace=True)

--- a/fiadoc/tests/fixtures/2024_10_race_classification.json
+++ b/fiadoc/tests/fixtures/2024_10_race_classification.json
@@ -1,0 +1,462 @@
+[
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "position": 1,
+                "is_classified": true,
+                "status": 0,
+                "points": 25.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5300227
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 2
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "position": 2,
+                "is_classified": true,
+                "status": 0,
+                "points": 19.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5302446
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 1
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "position": 3,
+                "is_classified": true,
+                "status": 0,
+                "points": 15.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5318017
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 4
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "position": 4,
+                "is_classified": true,
+                "status": 0,
+                "points": 12.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5322547
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 7
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "position": 5,
+                "is_classified": true,
+                "status": 0,
+                "points": 10.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5322936
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 6
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "position": 6,
+                "is_classified": true,
+                "status": 0,
+                "points": 8.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5331255
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 9
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "position": 7,
+                "is_classified": true,
+                "status": 0,
+                "points": 6.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5333987
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 5
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "position": 8,
+                "is_classified": true,
+                "status": 0,
+                "points": 4.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5359751
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 3
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "position": 9,
+                "is_classified": true,
+                "status": 0,
+                "points": 2.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5362252
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 13
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "position": 10,
+                "is_classified": true,
+                "status": 0,
+                "points": 1.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5372116
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 12
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "position": 11,
+                "is_classified": true,
+                "status": 0,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5379442
+                },
+                "laps_completed": 66,
+                "fastest_lap_rank": 10
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "position": 12,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5309724
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 8
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "position": 13,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5315703
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 11
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "position": 14,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5325479
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 15
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "position": 15,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5344277
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 17
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "position": 16,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5353540
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 18
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "position": 17,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5355015
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 19
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "position": 18,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5358376
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 14
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "position": 19,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5369131
+                },
+                "laps_completed": 65,
+                "fastest_lap_rank": 16
+            }
+        ]
+    },
+    {
+        "object_type": "SessionEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "position": 20,
+                "is_classified": true,
+                "status": 1,
+                "points": 0.0,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 5305093
+                },
+                "laps_completed": 64,
+                "fastest_lap_rank": 20
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2024_10_race_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_10_race_lap_times.json
@@ -1,0 +1,12012 @@
+[
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 1
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83186
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79871
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79364
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80766
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80827
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80876
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80973
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80989
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81042
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81003
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80954
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81376
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80807
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80989
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81097
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81223
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84876
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97657
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79725
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79966
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80304
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79742
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79605
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79701
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79363
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79882
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79694
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80101
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79792
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79807
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80011
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79891
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79836
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79958
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80185
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79926
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79803
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79813
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79669
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80310
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79648
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79920
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80301
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83427
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97053
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77886
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77998
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78416
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78254
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78074
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77958
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78140
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77776
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 55,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78021
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78354
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78127
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78187
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78114
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78165
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78360
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78301
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78543
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79072
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79467
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79774
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 2
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 91507
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83613
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82491
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82557
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83637
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83369
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83345
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82787
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82871
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82588
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82461
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83105
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86379
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99619
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80908
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81077
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81379
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81554
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81622
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81340
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81884
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81942
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83109
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82330
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82547
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82578
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82425
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82812
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82721
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82444
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82943
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85825
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100595
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80274
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80402
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80172
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 39,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80416
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80448
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80747
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82818
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82888
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80945
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81041
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82298
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81073
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80983
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81939
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81025
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81083
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81199
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81966
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82226
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82922
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81489
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81553
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84685
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81305
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81376
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81612
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85203
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 3
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 91751
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82721
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82652
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82374
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83005
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82920
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83484
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83066
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82436
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81770
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82102
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81857
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81974
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81902
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82433
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86262
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100003
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80858
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81881
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80964
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80849
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81358
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81123
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81122
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81337
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81663
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81558
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81430
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81052
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81542
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81578
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81117
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81170
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81059
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81140
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81188
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82205
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81540
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84891
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101373
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81034
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82469
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80945
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80930
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83762
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81912
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79843
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79585
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81027
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80084
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80277
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80999
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80128
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79768
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81548
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79996
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79556
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79450
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 62,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79800
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79870
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80194
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79527
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 4
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83953
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80215
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80243
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80702
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81134
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81056
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81293
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81443
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81143
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81223
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81285
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81354
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81432
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81660
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81541
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80908
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80447
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80635
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80816
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80907
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80928
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85185
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97673
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78503
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79856
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79317
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79835
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79720
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79389
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80145
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79868
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80090
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79855
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80478
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79447
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79225
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79307
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79215
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79745
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78911
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79511
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79499
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79457
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78754
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79419
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82986
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97126
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77377
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77940
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77115
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 52,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77654
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77914
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77987
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78363
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77627
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77893
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78259
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77945
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78271
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77805
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78080
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78174
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78282
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79682
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 10
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86584
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81157
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80806
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80679
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80780
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81303
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81625
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81748
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81681
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81711
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81339
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81638
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81678
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85491
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 102656
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79989
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80203
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80396
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80432
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80163
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80678
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80544
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80419
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80496
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80637
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80468
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81618
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81281
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80920
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80909
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80944
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80991
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80939
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82534
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81527
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81010
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81282
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85413
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97749
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79539
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80018
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79640
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79825
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79618
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79516
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79441
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79528
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79520
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79350
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79610
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79045
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 52,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79079
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79174
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79049
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79466
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79134
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79247
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79584
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79576
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79662
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79810
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79867
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80054
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79808
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82054
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 11
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 88615
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82234
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81849
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82097
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81655
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81526
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81490
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82010
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81481
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81680
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81734
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81983
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85586
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99168
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80167
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80583
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80420
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80162
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80559
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80661
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81205
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81082
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80609
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80593
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80821
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80918
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82179
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81234
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81403
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85420
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96491
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78652
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79548
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79316
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78936
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79059
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79488
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78990
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79367
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79387
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79072
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79480
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79617
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79469
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79406
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79846
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79811
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83203
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96990
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77785
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 52,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78373
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78290
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78430
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78540
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78572
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78935
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79305
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79193
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79017
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78772
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78934
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79688
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79357
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79124
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79151
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 14
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 89190
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82501
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81912
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81955
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82593
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83536
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83456
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82542
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82353
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82426
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81955
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81050
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81589
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81855
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81840
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82546
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83260
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82186
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85298
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98729
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80488
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80345
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81140
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81199
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81291
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81391
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81411
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81457
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81426
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81276
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80904
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81093
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81916
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81192
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81028
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80993
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80536
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82382
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81113
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81139
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80537
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80435
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80539
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84032
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98308
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78972
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78727
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78719
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78334
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 51,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78902
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79666
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78712
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79280
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79025
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81003
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79355
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79876
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80583
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79652
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79617
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79640
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79387
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79743
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 16
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85423
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80842
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81287
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80569
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80932
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81227
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80996
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81393
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81330
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81014
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81476
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81561
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81275
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81594
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81703
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80893
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81123
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80915
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81096
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81159
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81497
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81451
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81723
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85337
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98462
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79381
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78811
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79324
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79482
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79675
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79791
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79509
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79535
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79610
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80177
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79907
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79553
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79640
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79459
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79665
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79662
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79781
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79981
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80064
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79901
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80001
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83761
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97516
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78090
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78182
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78179
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77897
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 53,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77956
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78385
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78551
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78530
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78110
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78213
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78185
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78447
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78735
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78533
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78965
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79030
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79074
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79410
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 18
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 89606
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82004
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82128
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82263
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82130
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82416
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82359
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81858
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81750
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81967
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82256
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82185
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81768
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81918
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81955
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99122
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80615
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80783
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81212
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81328
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81366
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81568
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81131
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81092
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81300
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81244
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81101
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81454
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81481
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81275
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80972
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81339
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82413
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81262
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85201
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100958
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80421
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80289
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80921
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80926
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81539
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81548
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80288
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80301
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79704
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79749
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79341
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79318
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 51,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79739
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81436
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79832
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79488
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80854
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79643
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79541
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79595
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79627
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79747
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81533
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80020
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80139
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83904
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 20
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 90633
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83073
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82102
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82380
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83042
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82446
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82220
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82195
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86084
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100571
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81470
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80964
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81224
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81439
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81510
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81340
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81287
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80950
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82488
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81786
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81595
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82566
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82057
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81716
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81817
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82342
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81945
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85381
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 107447
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80045
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79927
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79805
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 34,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80206
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80298
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80480
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80488
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80327
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81685
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80948
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80912
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81124
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80884
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81131
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80967
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81784
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80940
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81147
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83892
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82938
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81932
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80894
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80638
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80584
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82164
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81049
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80996
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81022
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80994
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81008
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81366
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81450
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 22
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 90324
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82957
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82193
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82407
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82919
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83724
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83735
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82959
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86004
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98886
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81644
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82341
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81817
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81511
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81553
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81523
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82182
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81744
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82962
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81392
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83793
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81748
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81615
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81791
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82011
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85581
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99737
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79573
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79755
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80378
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80323
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80172
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80557
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80188
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82771
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80653
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80849
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81026
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82100
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81475
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84313
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86386
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101067
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80706
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80461
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82703
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81799
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79815
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79678
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79818
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80029
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80437
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79564
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79447
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 57,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79464
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79642
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80129
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80117
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84052
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80309
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80103
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80515
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 23
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 93920
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82217
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82171
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82278
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82775
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82498
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83531
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83225
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82838
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82787
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82421
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82119
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82263
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82246
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82595
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83579
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83526
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86838
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100225
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80005
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80288
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80494
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 20,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81052
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81181
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80945
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81477
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81645
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81416
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81102
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81419
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81252
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81170
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80993
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81283
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81636
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81479
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81577
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81737
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82269
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82155
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84250
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85925
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79132
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 46,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83125
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79852
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82037
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79881
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80077
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81430
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80131
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80220
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80300
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80197
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81742
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80119
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 89605
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80097
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79876
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80002
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79993
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80211
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80235
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80310
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 24
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 91052
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83016
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82516
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82358
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82810
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82951
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82487
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82570
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85889
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98315
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80219
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80151
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80739
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81869
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81376
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81382
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81607
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81546
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81379
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81512
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81790
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81671
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81561
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80469
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81268
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81179
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81254
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81057
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81471
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81426
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81387
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80995
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81273
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81418
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82152
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81523
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81230
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81386
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82219
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85635
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 101908
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78979
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79246
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79373
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79226
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79198
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79138
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78918
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78771
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 51,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79426
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79908
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80885
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80055
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81227
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79544
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80813
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79368
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79651
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79743
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79809
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79831
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79787
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80010
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80985
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 27
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 87970
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82084
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81383
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81949
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81858
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81545
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81698
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81841
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81629
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81852
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81994
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 87477
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100395
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80698
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80312
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81125
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81428
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80756
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81174
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81137
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81205
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82174
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81627
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80907
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81053
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80972
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81420
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81090
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80979
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81198
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81314
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81445
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81203
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81627
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81255
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81040
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81020
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84542
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99454
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80452
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80122
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80356
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79023
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79532
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79415
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79363
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79264
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78916
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78609
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 50,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79150
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78943
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79107
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79124
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79451
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79559
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79163
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79704
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79661
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80015
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79572
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79872
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79304
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79660
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79985
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80164
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81126
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 31
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 87460
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82017
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80809
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81255
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81536
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81290
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81593
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81784
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81790
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81756
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81905
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86687
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98526
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79883
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80224
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81541
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80571
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81026
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80662
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80768
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80734
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80949
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80570
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81357
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81269
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81644
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82216
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83348
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81776
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81194
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81433
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81479
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81702
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81423
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85378
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97672
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81476
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79592
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79889
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79705
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79626
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 11,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79810
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79706
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79525
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79802
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79468
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79614
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79601
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80010
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79321
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79061
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78982
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 55,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79284
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79260
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79324
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79564
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80041
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79687
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79751
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79940
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80663
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 44
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84441
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80594
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80421
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80496
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81050
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81200
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81223
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81538
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81207
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81380
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81192
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81505
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81450
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81601
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81977
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84966
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98332
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80038
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79307
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79703
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79915
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80008
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79788
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80059
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79972
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79915
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80590
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80236
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79757
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79896
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80327
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81357
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80258
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79986
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80651
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80606
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79404
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79658
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80037
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80032
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79600
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80224
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84149
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 96194
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78759
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77809
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 47,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78212
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78840
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78976
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78209
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78277
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78417
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78605
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78533
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78788
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78432
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78623
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78688
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78640
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78635
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78839
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79337
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78942
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79166
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79009
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80041
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 55
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 86085
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80666
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80046
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80626
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80800
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81217
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81146
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81309
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81221
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81052
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81459
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81620
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81163
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81646
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85427
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98064
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80665
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79850
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81079
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80000
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80125
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79952
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80261
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80205
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79709
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80273
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81788
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80458
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80061
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80376
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80642
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80183
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80145
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80231
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80708
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83733
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 98592
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78860
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78539
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 40,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79184
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78909
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79135
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79157
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79192
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79136
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80032
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79020
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79318
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79520
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79202
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79046
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79046
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79259
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79017
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81334
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79047
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78970
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78871
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78978
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79115
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79151
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79365
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79479
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79535
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79612
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79643
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 63
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82568
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 1,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79857
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81103
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80843
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80923
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81070
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81306
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81436
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81168
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81308
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81061
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81383
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81365
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81482
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85364
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 100240
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80277
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79511
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79539
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79972
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80340
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80093
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79871
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80032
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79772
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80279
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80222
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80201
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80027
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80038
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80338
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80301
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80178
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 2,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80204
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82129
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84372
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99351
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78367
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78964
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79428
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78982
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79033
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 6,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79306
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79019
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79632
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78291
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78486
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80060
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78681
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78290
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 51,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78726
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80241
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78863
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78860
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78572
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78792
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78956
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78641
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78877
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79108
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79267
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79304
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79520
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79372
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79634
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79751
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 77
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 90001
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82715
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82113
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82291
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82662
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82336
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82300
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82503
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82292
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82314
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85342
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99211
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79608
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 14,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80017
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81085
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81257
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81601
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81230
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81612
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81686
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81931
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82239
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 12,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81782
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 13,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83041
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 14,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83001
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83428
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 85577
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 19,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99622
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80195
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80470
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 18,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81613
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80565
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80744
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80666
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80604
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80815
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80773
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82774
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81055
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 17,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84249
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80477
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82645
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81338
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80810
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80891
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81055
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82101
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80644
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82406
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82596
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 83642
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80795
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80810
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80369
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 57,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79936
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81902
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 15,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80390
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82699
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81160
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80876
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80747
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81325
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 16,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81432
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    },
+    {
+        "object_type": "lap",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 10,
+            "session": "R",
+            "car_number": 81
+        },
+        "objects": [
+            {
+                "number": 1,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 87073
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 2,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81607
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 3,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80765
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 4,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80797
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 5,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81215
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 6,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81056
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 7,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81416
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 8,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81530
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 9,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81500
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 10,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82049
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 11,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81486
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 12,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81683
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 13,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81918
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 14,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 82316
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 15,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81492
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 16,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81532
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 17,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81853
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 18,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81505
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 19,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81727
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 20,
+                "position": 3,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 81883
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 21,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 87064
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 22,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 99096
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 23,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79833
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 24,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79991
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 25,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79731
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 26,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79853
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 27,
+                "position": 10,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80231
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 28,
+                "position": 9,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80626
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 29,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79823
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 30,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80010
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 31,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79875
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 32,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80425
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 33,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80543
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 34,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79656
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 35,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79796
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 36,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79728
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 37,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79661
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 38,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79785
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 39,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79780
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 40,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79659
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 41,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79622
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 42,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79930
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 43,
+                "position": 5,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80150
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 44,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79925
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 45,
+                "position": 4,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 80667
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 46,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 84084
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 47,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 97819
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 48,
+                "position": 8,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79317
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 49,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78159
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 50,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78257
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 51,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78181
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 52,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78492
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 53,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78223
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 54,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78354
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 55,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77941
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 56,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77874
+                },
+                "is_entry_fastest_lap": true
+            },
+            {
+                "number": 57,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78293
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 58,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78483
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 59,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78337
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 60,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78129
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 61,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 77977
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 62,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78186
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 63,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78587
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 64,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 78840
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 65,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79297
+                },
+                "is_entry_fastest_lap": false
+            },
+            {
+                "number": 66,
+                "position": 7,
+                "time": {
+                    "_type": "timedelta",
+                    "milliseconds": 79294
+                },
+                "is_entry_fastest_lap": false
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/test_parse_race.py
+++ b/fiadoc/tests/test_parse_race.py
@@ -27,7 +27,19 @@ race_list = [
         'sprint_race',
         '2023_18_sprint_classification.json',
         '2023_18_sprint_lap_times.json'
-    )
+    ),
+    (
+        # test an event without unclassified drivers
+        '2024_10_esp_f1_r0_timing_raceprovisionalclassification_v01_1.pdf',
+        '2024_10_esp_f1_r0_timing_racelapanalysis_v01_1.pdf',
+        '2024_10_esp_f1_r0_timing_racehistorychart_v01_1.pdf',
+        '2024_10_esp_f1_r0_timing_racelapchart_v01_1.pdf',
+        2024,
+        10,
+        'race',
+        '2024_10_race_classification.json',
+        '2024_10_race_lap_times.json'
+    ),
 ]
 
 


### PR DESCRIPTION
Fixes a problem where the ``is_classifed`` column may be missing. This happens when all drivers are classified (example: 2024, round 10, Spanish GP).

``is_classified`` was only set to ``False`` for drivers that aren't classified. But ``.fillna`` does not create missing columns. Therefore, if all drivers are classified, this column is never explicitly created and ``.fillna`` will not create it either and the column will be missing.