### PR TITLE
Handle driver incorrectly being marked as having a reserve

### DIFF
--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -134,6 +134,17 @@ class EntryListParser:
         df['reserve_for'] = None
         for i in df.reserve.dropna().unique():
             temp = df[df.reserve == i]
+            if len(temp) == 1:
+                # handle the case where a driver is incorrectly indicated as
+                # having a reserve driver, e.g. copy-paste error 2024, round 5
+                df.loc[df.reserve == i, 'reserve'] = None
+                warnings.warn(
+                    f'Driver {temp.driver.iloc[0]} is indicated as being or '
+                    f'having a reserve driver but no associated driver was '
+                    f'found!'
+                )
+                continue
+
             assert len(temp) == 2, f'Expected 2 rows for superscript {i}, got {len(temp)}'
             assert temp.car_no.nunique() == 2, \
                 f'Expected 2 different drivers for superscript {i}, got {temp.car_no.nunique()}'

--- a/fiadoc/tests/fixtures/2024_05_entry_list.json
+++ b/fiadoc/tests/fixtures/2024_05_entry_list.json
@@ -1,0 +1,282 @@
+[
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Max Verstappen",
+            "team_name": "Red Bull Racing Honda RBPT"
+        },
+        "objects": [
+            {
+                "car_number": 1
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Sergio Perez",
+            "team_name": "Red Bull Racing Honda RBPT"
+        },
+        "objects": [
+            {
+                "car_number": 11
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "George Russell",
+            "team_name": "Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 63
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Lewis Hamilton",
+            "team_name": "Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 44
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Charles Leclerc",
+            "team_name": "Ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 16
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Carlos Sainz",
+            "team_name": "Ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 55
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Oscar Piastri",
+            "team_name": "McLaren Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 81
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Lando Norris",
+            "team_name": "McLaren Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 4
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Lance Stroll",
+            "team_name": "Aston Martin Aramco Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 18
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Fernando Alonso",
+            "team_name": "Aston Martin Aramco Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 14
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Esteban Ocon",
+            "team_name": "Alpine Renault"
+        },
+        "objects": [
+            {
+                "car_number": 31
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Pierre Gasly",
+            "team_name": "Alpine Renault"
+        },
+        "objects": [
+            {
+                "car_number": 10
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Alexander Albon",
+            "team_name": "Williams Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 23
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Logan Sargeant",
+            "team_name": "Williams Mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 2
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Daniel Ricciardo",
+            "team_name": "RB Honda RBPT"
+        },
+        "objects": [
+            {
+                "car_number": 3
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Yuki Tsunoda",
+            "team_name": "RB Honda RBPT"
+        },
+        "objects": [
+            {
+                "car_number": 22
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Valtteri Bottas",
+            "team_name": "Kick Sauber Ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 77
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Zhou Guanyu",
+            "team_name": "Kick Sauber Ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 24
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Kevin Magnussen",
+            "team_name": "Haas Ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 20
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 5,
+            "driver_name": "Nico Hulkenberg",
+            "team_name": "Haas Ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 27
+            }
+        ]
+    }
+]


### PR DESCRIPTION
In the Entry List for the 2024 Japanese Grand Prix, RIC is incorrectly marked as having a reserve driver but he had none.
This looks like a copy-paster error from the previous Chinese GP were he had a reserve driver. Compare

https://www.fia.com/sites/default/files/decision-document/2024%20Japanese%20Grand%20Prix%20-%20Entry%20List.pdf

https://www.fia.com/sites/default/files/decision-document/2024%20Chinese%20Grand%20Prix%20-%20Entry%20List.pdf

The issue persists for the Miami GP as well and is only fixed after that.

The code will now handle this gracefully, remove the reserve marking and output a warning.

Edit: I also added a test that checks if the Chinese GP Entry List can be parsed and ensures that the warning is output.