### PR TITLE
Skip drivers that are missing from driver mapping in entry list

### DIFF
--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -50,9 +50,6 @@ DRIVERS = {
         'Oliver Bearman': 'bearman',
         'Franco Colapinto': 'colapinto',
         'Jack Doohan': 'doohan',
-        'Patricio O’Ward': 'oward',         # TODO: inconsistent with jolpica
-        'Felipe Drugovich': 'drugovich',    # TODO: inconsistent with jolpica
-        'Robert Shwartzman': 'shwartzman',  # TODO: inconsistent with jolpica
         'Liam Lawson': 'lawson',
         'Andrea Kimi Antonelli': 'antonelli'
     },

--- a/fiadoc/tests/fixtures/2024_04_entry_list.json
+++ b/fiadoc/tests/fixtures/2024_04_entry_list.json
@@ -1,0 +1,282 @@
+[
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "max_verstappen",
+            "team_reference": "red_bull"
+        },
+        "objects": [
+            {
+                "car_number": 1
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "perez",
+            "team_reference": "red_bull"
+        },
+        "objects": [
+            {
+                "car_number": 11
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "russell",
+            "team_reference": "mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 63
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "hamilton",
+            "team_reference": "mercedes"
+        },
+        "objects": [
+            {
+                "car_number": 44
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "leclerc",
+            "team_reference": "ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 16
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "sainz",
+            "team_reference": "ferrari"
+        },
+        "objects": [
+            {
+                "car_number": 55
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "piastri",
+            "team_reference": "mclaren"
+        },
+        "objects": [
+            {
+                "car_number": 81
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "norris",
+            "team_reference": "mclaren"
+        },
+        "objects": [
+            {
+                "car_number": 4
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "stroll",
+            "team_reference": "aston_martin"
+        },
+        "objects": [
+            {
+                "car_number": 18
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "alonso",
+            "team_reference": "aston_martin"
+        },
+        "objects": [
+            {
+                "car_number": 14
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "ocon",
+            "team_reference": "alpine"
+        },
+        "objects": [
+            {
+                "car_number": 31
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "gasly",
+            "team_reference": "alpine"
+        },
+        "objects": [
+            {
+                "car_number": 10
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "albon",
+            "team_reference": "williams"
+        },
+        "objects": [
+            {
+                "car_number": 23
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "sargeant",
+            "team_reference": "williams"
+        },
+        "objects": [
+            {
+                "car_number": 2
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "ricciardo",
+            "team_reference": "rb"
+        },
+        "objects": [
+            {
+                "car_number": 3
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "tsunoda",
+            "team_reference": "rb"
+        },
+        "objects": [
+            {
+                "car_number": 22
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "bottas",
+            "team_reference": "sauber"
+        },
+        "objects": [
+            {
+                "car_number": 77
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "zhou",
+            "team_reference": "sauber"
+        },
+        "objects": [
+            {
+                "car_number": 24
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "kevin_magnussen",
+            "team_reference": "haas"
+        },
+        "objects": [
+            {
+                "car_number": 20
+            }
+        ]
+    },
+    {
+        "object_type": "RoundEntry",
+        "foreign_keys": {
+            "year": 2024,
+            "round": 4,
+            "driver_reference": "hulkenberg",
+            "team_reference": "haas"
+        },
+        "objects": [
+            {
+                "car_number": 27
+            }
+        ]
+    }
+]

--- a/fiadoc/tests/fixtures/2024_20_entry_list.json
+++ b/fiadoc/tests/fixtures/2024_20_entry_list.json
@@ -284,20 +284,6 @@
         "foreign_keys": {
             "year": 2024,
             "round": 20,
-            "driver_reference": "oward",
-            "team_reference": "mclaren"
-        },
-        "objects": [
-            {
-                "car_number": 29
-            }
-        ]
-    },
-    {
-        "object_type": "RoundEntry",
-        "foreign_keys": {
-            "year": 2024,
-            "round": 20,
             "driver_reference": "antonelli",
             "team_reference": "mercedes"
         },
@@ -312,40 +298,12 @@
         "foreign_keys": {
             "year": 2024,
             "round": 20,
-            "driver_reference": "drugovich",
-            "team_reference": "aston_martin"
-        },
-        "objects": [
-            {
-                "car_number": 34
-            }
-        ]
-    },
-    {
-        "object_type": "RoundEntry",
-        "foreign_keys": {
-            "year": 2024,
-            "round": 20,
             "driver_reference": "bearman",
             "team_reference": "ferrari"
         },
         "objects": [
             {
                 "car_number": 38
-            }
-        ]
-    },
-    {
-        "object_type": "RoundEntry",
-        "foreign_keys": {
-            "year": 2024,
-            "round": 20,
-            "driver_reference": "shwartzman",
-            "team_reference": "sauber"
-        },
-        "objects": [
-            {
-                "car_number": 97
             }
         ]
     }

--- a/fiadoc/tests/test_parse_entry_list.py
+++ b/fiadoc/tests/test_parse_entry_list.py
@@ -29,6 +29,15 @@ race_list = [
         nullcontext()
     ),
     (
+        # handle gracefully if driver is not found in the driver mapping
+        # (e.g. reserve driver not in the mapping) and warn user
+        '2024%20Japanese%20Grand%20Prix%20-%20Entry%20List.pdf',
+        2024,
+        4,
+        '2024_04_entry_list.json',
+        pytest.warns(UserWarning, match='Error when parsing driver Ayumu')
+    ),
+    (
         # RIC incorrectly indicated as having a reserve driver here
         # (looks like copy-paste error from previous race) -> handle gracefully
         '2024%20Chinese%20Grand%20Prix%20-%20Entry%20List.pdf',
@@ -51,10 +60,9 @@ def prepare_entry_list_data(request, tmp_path) -> tuple[list[dict], list[dict]]:
 
     with context:
         parser = EntryListParser(tmp_path / 'entry_list.pdf', year, round_no)
-
+        data = parser.df.to_json()
 
     # Sort by car No. for both json for easier comparison
-    data = parser.df.to_json()
     with open('fiadoc/tests/fixtures/' + expected, encoding='utf-8') as f:
         expected_data = json.load(f)
     data.sort(key=lambda x: x['objects'][0]['car_number'])

--- a/fiadoc/tests/test_parse_entry_list.py
+++ b/fiadoc/tests/test_parse_entry_list.py
@@ -26,7 +26,9 @@ race_list = [
         2024,
         20,
         '2024_20_entry_list.json',
-        nullcontext()
+        # multiple reserve drivers that must be skipped on export to json
+        # because they are not in the driver mapping
+        pytest.warns(UserWarning, match='Error when parsing driver')
     ),
     (
         # handle gracefully if driver is not found in the driver mapping


### PR DESCRIPTION
With the introduction of the new driver mapping ``.to_json`` now fails when the Entry List contains reserve drivers.

Given that the reserve drivers mostly only drive in practice sessions, I suggest skipping these entries.
Alternatively, we could reintroduce the driver name in the export JSON and make the driver reference nullable in these cases.

This PR implements the variant where these drivers are skipped.

Additionally, a test is added for a PDF that contains reserve drivers.