### PR TITLE
Unify session names and introduce stronger typing

### DIFF
--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -3,7 +3,10 @@ import os
 import pickle
 import re
 import warnings
-from enum import Enum
+from typing import (
+    get_args,
+    Literal
+)
 
 import numpy as np
 import pandas as pd
@@ -24,14 +27,8 @@ from .utils import Page, duration_to_millisecond, time_to_timedelta
 pd.set_option('future.no_silent_downcasting', True)
 
 
-class RaceSession(str, Enum):
-    Race = 'race'
-    Sprint = 'sprint'
-
-
-class QualiSession(str, Enum):
-    Quali = 'quali'
-    SprintQuali = 'sprint_quali'
+RaceSessionT = Literal['race', 'sprint']
+QualiSessionT = Literal['quali', 'sprint_quali']
 
 
 class EntryListParser:
@@ -284,7 +281,7 @@ class RaceParser:
             lap_chart_file: str | os.PathLike,
             year: int,
             round_no: int,
-            session: RaceSession
+            session: RaceSessionT
     ):
         self.classification_file = classification_file
         self.lap_analysis_file = lap_analysis_file
@@ -300,11 +297,9 @@ class RaceParser:
 
     def _check_session(self) -> None:
         """Check that the input session is valid. Raise an error otherwise"""
-        try:
-            self.session = RaceSession(self.session)
-        except ValueError:
+        if self.session not in get_args(RaceSessionT):
             raise ValueError(f'Invalid session: {self.session}. '
-                             f'Valid sessions are: {[s.value for s in RaceSession]}')
+                             f'Valid sessions are: {get_args(RaceSessionT)}')
         return
 
     def _parse_classification(self) -> pd.DataFrame:
@@ -758,7 +753,7 @@ class RaceParser:
 
             # If it's race, then only three drivers (or less) on one page. And all of them should
             # start from the same y-coord. and have the same y-coord. for "LAP" and "TIME"
-            if self.session == RaceSession.Race:
+            if self.session == 'race':
                 assert len(laps) <= 6, f'Expected at most 6 "LAP" on p.{page.number} in ' \
                                        f'{self.lap_analysis_file}. Found {len(laps)}'
                 for i in range(len(laps) - 1):
@@ -786,7 +781,7 @@ class RaceParser:
             # Horizontally, three drivers share the full width of the page, side by side. If it's
             # race, then three drivers (or less) on one page
             # See QualifyingParser._parse_lap_times() for detailed explanation
-            if self.session == RaceSession.Race:
+            if self.session == 'race':
                 w = r / 3
                 for i in range(3):
                     # Driver's name is below "Race Lap Analysis" and above the table
@@ -1100,7 +1095,7 @@ class RaceParser:
                 lambda x: SessionEntry(
                     year=self.year,
                     round=self.round_no,
-                    session='R' if self.session == RaceSession.Race else 'SR',
+                    session='R' if self.session == 'race' else 'SR',
                     car_number=x
                 )
             )
@@ -1138,7 +1133,7 @@ class QualifyingParser:
             lap_times_file: str | os.PathLike,
             year: int,
             round_no: int,
-            session: QualiSession
+            session: QualiSessionT
     ):
         self.classification_file = classification_file
         self.lap_times_file = lap_times_file
@@ -1152,11 +1147,9 @@ class QualifyingParser:
 
     def _check_session(self) -> None:
         """Check that the input session is valid. Raise an error otherwise"""
-        try:
-            self.session = QualiSession(self.session)
-        except ValueError:
+        if self.session not in get_args(QualiSessionT):
             raise ValueError(f'Invalid session: {self.session}. '
-                             f'Valid sessions are: {[s.value for s in QualiSession]}"')
+                             f'Valid sessions are: {get_args(QualiSessionT)}"')
         # TODO: 2023 US sprint shootout. No "POLE POSITION LAP"???
         return
 
@@ -1320,7 +1313,7 @@ class QualifyingParser:
                         foreign_keys=SessionEntry(
                             year=self.year,
                             round=self.round_no,
-                            session=f'Q{q}' if self.session == QualiSession.Quali else f'SQ{q}',
+                            session=f'Q{q}' if self.session == 'quali' else f'SQ{q}',
                             car_number=x.NO
                         ),
                         objects=[
@@ -1631,7 +1624,7 @@ class QualifyingParser:
                     lambda x: SessionEntry(
                         year=self.year,
                         round=self.round_no,
-                        session=f'Q{q}' if self.session == QualiSession.Quali else f'SQ{q}',
+                        session=f'Q{q}' if self.session == 'quali' else f'SQ{q}',
                         car_number=x
                     )
                 )
@@ -1661,7 +1654,7 @@ class PitStopParser:
             file: str | os.PathLike,
             year: int,
             round_no: int,
-            session: RaceSession
+            session: RaceSessionT
     ):
         self.file = file
         self.year = year
@@ -1671,11 +1664,9 @@ class PitStopParser:
         self.df = self._parse()
 
     def _check_session(self) -> None:
-        try:
-            self.session = RaceSession(self.session)
-        except ValueError:
+        if self.session not in get_args(RaceSessionT):
             raise ValueError(f'Invalid session: {self.session}. '
-                             f'Valid sessions are {[s.value for s in RaceSession]}')
+                             f'Valid sessions are {get_args(RaceSessionT)}')
         return
 
     def _parse(self) -> pd.DataFrame:
@@ -1724,7 +1715,7 @@ class PitStopParser:
                 lambda x: PitStopEntry(
                     year=self.year,
                     round=self.round_no,
-                    session=self.session if self.session == RaceSession.Race else 'SR',
+                    session=self.session if self.session == 'race' else 'SR',
                     car_number=x.car_no,
                     lap=x.lap
                 ), axis=1

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -2,9 +2,8 @@
 import os
 import pickle
 import re
-from enum import StrEnum
-from typing import Literal
 import warnings
+from enum import Enum
 
 import numpy as np
 import pandas as pd
@@ -25,12 +24,12 @@ from .utils import Page, duration_to_millisecond, time_to_timedelta
 pd.set_option('future.no_silent_downcasting', True)
 
 
-class RaceSession(StrEnum):
+class RaceSession(str, Enum):
     Race = 'race'
     Sprint = 'sprint'
 
 
-class QualiSession(StrEnum):
+class QualiSession(str, Enum):
     Quali = 'quali'
     SprintQuali = 'sprint_quali'
 

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -300,7 +300,9 @@ class RaceParser:
 
     def _check_session(self) -> None:
         """Check that the input session is valid. Raise an error otherwise"""
-        if self.session not in RaceSession:
+        try:
+            self.session = RaceSession(self.session)
+        except ValueError:
             raise ValueError(f'Invalid session: {self.session}. '
                              f'Valid sessions are: {[s.value for s in RaceSession]}')
         return
@@ -1150,7 +1152,9 @@ class QualifyingParser:
 
     def _check_session(self) -> None:
         """Check that the input session is valid. Raise an error otherwise"""
-        if self.session not in QualiSession:
+        try:
+            self.session = QualiSession(self.session)
+        except ValueError:
             raise ValueError(f'Invalid session: {self.session}. '
                              f'Valid sessions are: {[s.value for s in QualiSession]}"')
         # TODO: 2023 US sprint shootout. No "POLE POSITION LAP"???
@@ -1667,7 +1671,9 @@ class PitStopParser:
         self.df = self._parse()
 
     def _check_session(self) -> None:
-        if self.session not in RaceSession:
+        try:
+            self.session = RaceSession(self.session)
+        except ValueError:
             raise ValueError(f'Invalid session: {self.session}. '
                              f'Valid sessions are {[s.value for s in RaceSession]}')
         return

--- a/fiadoc/tests/test_parse_race.py
+++ b/fiadoc/tests/test_parse_race.py
@@ -24,7 +24,7 @@ race_list = [
         '2023_19_usa_f1_s0_timing_sprintlapchart_v01.pdf',
         2023,
         18,
-        'sprint_race',
+        'sprint',
         '2023_18_sprint_classification.json',
         '2023_18_sprint_lap_times.json'
     ),


### PR DESCRIPTION
Currently, the ``RaceParser`` accepts ``'race'`` or ``'sprint_race'`` as session argument while the ``PitStopParser`` accepts ``'race'`` and ``'sprint'``. Having these be the same makes much more sense.

~~Instead of just updating the strings, I propose to introduce two ``StrEnum`` classes here. This makes for overall stronger typing throughout the source code. It removes the risk of typos in strings scattered throughout the source code which can't be type checked.~~
I deliberately made these ~~enums~~ literal types public so that other packages can import them as well and have a consistent interface to fiadoc.

Note that because RaceParser and PitStopParser previously had different types for session, this is a breaking change right now. I can add a backwards compatibility, if you want, and also allow the old session name for the RaceParser.

What's your overall opinion on this?