### PR TITLE
Use jolpica schemas package for models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
 
     name: Tests on python ${{ matrix.python-version }}
     steps:

--- a/fiadoc/models/classification.py
+++ b/fiadoc/models/classification.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
-from typing import Optional
-
 from pydantic import (
-    BaseModel,
     ConfigDict,
-    NonNegativeFloat,
-    NonNegativeInt,
-    PositiveInt,
-    field_validator
 )
 
 from .foreign_key import SessionEntryForeignKeys
@@ -15,7 +8,7 @@ from jolpica.schemas import data_import
 
 
 class SessionEntryObject(data_import.SessionEntryObject):
-    time: dict[str, str | int] | None
+    time: dict[str, str | int] | None = None
 
     model_config = ConfigDict(extra='forbid')
 
@@ -23,18 +16,5 @@ class SessionEntryImport(data_import.SessionEntryImport):
     object_type: str = 'SessionEntry'
     foreign_keys: SessionEntryForeignKeys
     objects: list[SessionEntryObject]
-
-    model_config = ConfigDict(extra='forbid')
-
-
-class QualiClassification(BaseModel):
-    position: PositiveInt
-    is_classified: bool
-
-
-class QualiClassificationData(BaseModel):
-    object_type: str = 'SessionEntry'
-    foreign_keys: SessionEntryForeignKeys
-    objects: list[QualiClassification]
 
     model_config = ConfigDict(extra='forbid')

--- a/fiadoc/models/classification.py
+++ b/fiadoc/models/classification.py
@@ -10,26 +10,19 @@ from pydantic import (
     field_validator
 )
 
-from .foreign_key import SessionEntry
+from .foreign_key import SessionEntryForeignKeys
+from jolpica.schemas import data_import
 
 
-class Classification(BaseModel):
-    position: PositiveInt
-    is_classified: bool
-    status: NonNegativeInt
-    points: NonNegativeFloat
+class SessionEntryObject(data_import.SessionEntryObject):
     time: dict[str, str | int] | None
-    laps_completed: NonNegativeInt  # TODO: or positive int? What if retire in lap 1?
-    fastest_lap_rank: PositiveInt | None
-    grid: PositiveInt
 
     model_config = ConfigDict(extra='forbid')
 
-
-class ClassificationData(BaseModel):
+class SessionEntryImport(data_import.SessionEntryImport):
     object_type: str = 'SessionEntry'
-    foreign_keys: SessionEntry
-    objects: list[Classification]
+    foreign_keys: SessionEntryForeignKeys
+    objects: list[SessionEntryObject]
 
     model_config = ConfigDict(extra='forbid')
 
@@ -41,7 +34,7 @@ class QualiClassification(BaseModel):
 
 class QualiClassificationData(BaseModel):
     object_type: str = 'SessionEntry'
-    foreign_keys: SessionEntry
+    foreign_keys: SessionEntryForeignKeys
     objects: list[QualiClassification]
 
     model_config = ConfigDict(extra='forbid')

--- a/fiadoc/models/classification.py
+++ b/fiadoc/models/classification.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
+from jolpica.schemas import data_import
 from pydantic import (
     ConfigDict,
 )
 
 from .foreign_key import SessionEntryForeignKeys
-from jolpica.schemas import data_import
 
 
 class SessionEntryObject(data_import.SessionEntryObject):
     time: dict[str, str | int] | None = None
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
+
 
 class SessionEntryImport(data_import.SessionEntryImport):
-    object_type: str = 'SessionEntry'
+    object_type: str = "SessionEntry"
     foreign_keys: SessionEntryForeignKeys
     objects: list[SessionEntryObject]
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")

--- a/fiadoc/models/driver.py
+++ b/fiadoc/models/driver.py
@@ -3,18 +3,15 @@
 from pydantic import BaseModel, ConfigDict, PositiveInt
 
 from .foreign_key import RoundEntry
+from jolpica.schemas import data_import
 
 
-class Driver(BaseModel):
-    car_number: PositiveInt
-
+class RoundEntryObject(data_import.RoundEntryObject):
     model_config = ConfigDict(extra='forbid')
 
 
-class DriverData(BaseModel):
-    object_type: str = 'RoundEntry'
+class RoundEntryImport(data_import.RoundEntryImport):
     foreign_keys: RoundEntry
-
-    objects: list[Driver]
+    objects: list[RoundEntryObject]
 
     model_config = ConfigDict(extra='forbid')

--- a/fiadoc/models/driver.py
+++ b/fiadoc/models/driver.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 """Driver entry models"""
+
+from jolpica.schemas import data_import
 from pydantic import BaseModel, ConfigDict, PositiveInt
 
 from .foreign_key import RoundEntry
-from jolpica.schemas import data_import
 
 
 class RoundEntryObject(data_import.RoundEntryObject):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
 
 class RoundEntryImport(data_import.RoundEntryImport):
     foreign_keys: RoundEntry
     objects: list[RoundEntryObject]
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")

--- a/fiadoc/models/foreign_key.py
+++ b/fiadoc/models/foreign_key.py
@@ -1,63 +1,90 @@
 # -*- coding: utf-8 -*-
 """Frequently used foreign key models for the data objects"""
+
+from jolpica.schemas import data_import
+from pydantic import ConfigDict, field_validator, model_validator
 from typing_extensions import Self
 
-from pydantic import ConfigDict, field_validator, model_validator
-
 from .._constants import DRIVERS, TEAMS
-from jolpica.schemas import data_import
+
 
 class SessionValidatorMixin:
-    @field_validator('session')
+    @field_validator("session")
     @classmethod
     def clean_session(cls, session: str) -> str:
         match session.lower().strip():
-            case 'r' | 'q1' | 'q2' | 'q3' | 'sr' | 'sq1' | 'sq2' | 'sq3' | 'fp1' | 'fp2' | 'fp3':
+            case (
+                "r"
+                | "q1"
+                | "q2"
+                | "q3"
+                | "sr"
+                | "sq1"
+                | "sq2"
+                | "sq3"
+                | "fp1"
+                | "fp2"
+                | "fp3"
+            ):
                 return session.upper()
-            case 'race':  # Some simple mapping
-                return 'R'
-            case 'sprint' | 'sprint_race' | 'sprint race':
-                return 'SR'
+            case "race":  # Some simple mapping
+                return "R"
+            case "sprint" | "sprint_race" | "sprint race":
+                return "SR"
             case _:
-                raise ValueError(f'Invalid session: {session}. Must be one of: "R", "Q1", "Q2",'
-                                 f'"Q3", "SR", "SQ1", "SQ2", "SQ3", "FP1", "FP2", "FP3"')
-    
+                raise ValueError(
+                    f'Invalid session: {session}. Must be one of: "R", "Q1", "Q2",'
+                    f'"Q3", "SR", "SQ1", "SQ2", "SQ3", "FP1", "FP2", "FP3"'
+                )
 
-class SessionEntryForeignKeys(data_import.SessionEntryForeignKeys, SessionValidatorMixin):
-    model_config = ConfigDict(extra='forbid')
+
+class SessionEntryForeignKeys(
+    data_import.SessionEntryForeignKeys, SessionValidatorMixin
+):
+    model_config = ConfigDict(extra="forbid")
+
 
 class PitStopForeignKeys(data_import.PitStopForeignKeys, SessionValidatorMixin):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
+
 
 class RoundEntry(data_import.RoundEntryForeignKeys):
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     def get_team_reference(self) -> Self:
-        if self['year'] in TEAMS:
-            if self['team_reference'] in TEAMS[self['year']]:
-                self['team_reference'] = TEAMS[self['year']][self['team_reference']]
+        if self["year"] in TEAMS:
+            if self["team_reference"] in TEAMS[self["year"]]:
+                self["team_reference"] = TEAMS[self["year"]][self["team_reference"]]
                 return self
             else:
-                raise ValueError(f"team {self['team_reference']} not found in year "
-                                 f"{self['year']}'s team name mapping. Available teams: "
-                                 f"{TEAMS[self['year']].keys()}")
+                raise ValueError(
+                    f"team {self['team_reference']} not found in year "
+                    f"{self['year']}'s team name mapping. Available teams: "
+                    f"{TEAMS[self['year']].keys()}"
+                )
         else:
-            raise ValueError(f"year {self['year']} not found in team name mapping. Available "
-                             f'years: {TEAMS.keys()}')
+            raise ValueError(
+                f"year {self['year']} not found in team name mapping. Available "
+                f"years: {TEAMS.keys()}"
+            )
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     def get_driver_name(self) -> Self:
-        if self['year'] in DRIVERS:
-            if self['driver_reference'] in DRIVERS[self['year']]:
-                self['driver_reference'] = DRIVERS[self['year']][self['driver_reference']]
+        if self["year"] in DRIVERS:
+            if self["driver_reference"] in DRIVERS[self["year"]]:
+                self["driver_reference"] = DRIVERS[self["year"]][
+                    self["driver_reference"]
+                ]
                 return self
             else:
-                raise ValueError(f"driver {self['driver_reference']} not found in year "
-                                 f"{self['year']}'s driver name mapping. Available drivers: "
-                                 f"{DRIVERS[self['year']].keys()}")
+                raise ValueError(
+                    f"driver {self['driver_reference']} not found in year "
+                    f"{self['year']}'s driver name mapping. Available drivers: "
+                    f"{DRIVERS[self['year']].keys()}"
+                )
         else:
-            raise ValueError(f"year {self['year']} not found in driver name mapping. Available "
-                             f'years: {DRIVERS.keys()}')
+            raise ValueError(
+                f"year {self['year']} not found in driver name mapping. Available "
+                f"years: {DRIVERS.keys()}"
+            )
 
-    model_config = ConfigDict(extra='forbid')
-
-
+    model_config = ConfigDict(extra="forbid")

--- a/fiadoc/models/foreign_key.py
+++ b/fiadoc/models/foreign_key.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, PositiveInt, field_validator, model_
 from .._constants import DRIVERS, TEAMS
 
 
-class SessionEntry(BaseModel):
+class SessionEntryForeignKeys(BaseModel):
     year: PositiveInt
     round: PositiveInt
     session: str = Literal['R', 'Q1', 'Q2', 'Q3', 'SR', 'SQ1', 'SQ2', 'SQ3', 'FP1', 'FP2', 'FP3']

--- a/fiadoc/models/lap.py
+++ b/fiadoc/models/lap.py
@@ -2,29 +2,16 @@
 from pydantic import BaseModel, ConfigDict, PositiveInt
 
 from .foreign_key import SessionEntryForeignKeys
+from jolpica.schemas import data_import
 
 
-class Lap(BaseModel):
-    number: PositiveInt
-    position: PositiveInt
+class LapObject(data_import.LapObject):
     time: dict[str, str | int]
-    is_entry_fastest_lap: bool
-
     model_config = ConfigDict(extra='forbid')
 
 
-class QualiLap(BaseModel):
-    number: PositiveInt
-    time: dict[str, str | int]
-    is_deleted: bool
-    is_entry_fastest_lap: bool
-
-    model_config = ConfigDict(extra='forbid')
-
-
-class LapData(BaseModel):
-    object_type: str = 'Lap'
+class LapImport(data_import.LapImport):
     foreign_keys: SessionEntryForeignKeys
-    objects: list[Lap | QualiLap]
+    objects: list[LapObject]
 
     model_config = ConfigDict(extra='forbid')

--- a/fiadoc/models/lap.py
+++ b/fiadoc/models/lap.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from pydantic import BaseModel, ConfigDict, PositiveInt
 
-from .foreign_key import SessionEntry
+from .foreign_key import SessionEntryForeignKeys
 
 
 class Lap(BaseModel):
@@ -24,7 +24,7 @@ class QualiLap(BaseModel):
 
 class LapData(BaseModel):
     object_type: str = 'Lap'
-    foreign_keys: SessionEntry
+    foreign_keys: SessionEntryForeignKeys
     objects: list[Lap | QualiLap]
 
     model_config = ConfigDict(extra='forbid')

--- a/fiadoc/models/lap.py
+++ b/fiadoc/models/lap.py
@@ -23,7 +23,7 @@ class QualiLap(BaseModel):
 
 
 class LapData(BaseModel):
-    object_type: str = 'lap'
+    object_type: str = 'Lap'
     foreign_keys: SessionEntry
     objects: list[Lap | QualiLap]
 

--- a/fiadoc/models/lap.py
+++ b/fiadoc/models/lap.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
+from jolpica.schemas import data_import
 from pydantic import BaseModel, ConfigDict, PositiveInt
 
 from .foreign_key import SessionEntryForeignKeys
-from jolpica.schemas import data_import
 
 
 class LapObject(data_import.LapObject):
     time: dict[str, str | int]
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
 
 class LapImport(data_import.LapImport):
     foreign_keys: SessionEntryForeignKeys
     objects: list[LapObject]
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")

--- a/fiadoc/models/pit_stop.py
+++ b/fiadoc/models/pit_stop.py
@@ -19,22 +19,25 @@
     ]
 }
 """
+
 from datetime import timedelta
 
+from jolpica.schemas import data_import
 from pydantic import BaseModel, ConfigDict, PositiveInt
 
 from .foreign_key import PitStopForeignKeys
-from jolpica.schemas import data_import
 
 
 class PitStopObject(data_import.PitStopObject):
     duration: dict[str, str | int]
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
 
-class PitStopData(data_import.PitStopImport):  # TODO: all xxxData can be combined into one class?
+class PitStopData(
+    data_import.PitStopImport
+):  # TODO: all xxxData can be combined into one class?
     foreign_keys: PitStopForeignKeys
     objects: list[PitStopObject]
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")

--- a/fiadoc/models/pit_stop.py
+++ b/fiadoc/models/pit_stop.py
@@ -21,22 +21,20 @@
 """
 from datetime import timedelta
 
-from pydantic import BaseModel, PositiveInt
+from pydantic import BaseModel, ConfigDict, PositiveInt
 
-from .foreign_key import PitStopEntry
+from .foreign_key import PitStopForeignKeys
+from jolpica.schemas import data_import
 
 
-class PitStop(BaseModel):
-    number: PositiveInt  # Car No.
+class PitStopObject(data_import.PitStopObject):
     duration: dict[str, str | int]
-    local_timestamp: str
 
-    model_config = {'extra': 'forbid'}
+    model_config = ConfigDict(extra='forbid')
 
 
-class PitStopData(BaseModel):  # TODO: all xxxData can be combined into one class?
-    object_type: str = 'PitStop'
-    foreign_keys: PitStopEntry
-    objects: list[PitStop]
+class PitStopData(data_import.PitStopImport):  # TODO: all xxxData can be combined into one class?
+    foreign_keys: PitStopForeignKeys
+    objects: list[PitStopObject]
 
-    model_config = {'extra': 'forbid'}
+    model_config = ConfigDict(extra='forbid')

--- a/fiadoc/models/pit_stop.py
+++ b/fiadoc/models/pit_stop.py
@@ -35,7 +35,7 @@ class PitStop(BaseModel):
 
 
 class PitStopData(BaseModel):  # TODO: all xxxData can be combined into one class?
-    object_type: str = 'pit_stop'
+    object_type: str = 'PitStop'
     foreign_keys: PitStopEntry
     objects: list[PitStop]
 

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -14,13 +14,13 @@ from typing_extensions import Self
 
 from ._constants import QUALI_DRIVERS
 from .models.classification import(
-    Classification,
-    ClassificationData,
+    SessionEntryObject,
+    SessionEntryImport,
     QualiClassification,
     QualiClassificationData
 )
 from .models.driver import Driver, DriverData
-from .models.foreign_key import PitStopEntry, RoundEntry, SessionEntry
+from .models.foreign_key import PitStopEntry, RoundEntry, SessionEntryForeignKeys
 from .models.lap import Lap, LapData, QualiLap
 from .models.pit_stop import PitStop, PitStopData
 from .utils import Page, duration_to_millisecond, time_to_timedelta
@@ -34,63 +34,63 @@ pd.set_option('future.no_silent_downcasting', True)
 RaceSessionT = Literal['race', 'sprint']
 QualiSessionT = Literal['quali', 'sprint_quali']
 
-class SessionEntryObjectJson(data_import.SessionEntryObject):
-    time: dict[str, str | int]
+# class SessionEntryObjectJson(data_import.SessionEntryObject):
+#     time: dict[str, str | int]
 
-class PitStopObjectJson(data_import.PitStopObject):
-    duration: dict[str, str | int]
+# class PitStopObjectJson(data_import.PitStopObject):
+#     duration: dict[str, str | int]
 
-class LapObjectJson(data_import.LapObject):
-    time: dict[str, str | int]
+# class LapObjectJson(data_import.LapObject):
+#     time: dict[str, str | int]
 
-class ValidatorMixin:
-    @field_validator('session')
-    @classmethod
-    def clean_session(cls, session: str) -> str:
-        match session.lower().strip():
-            case 'r' | 'q1' | 'q2' | 'q3' | 'sr' | 'sq1' | 'sq2' | 'sq3' | 'fp1' | 'fp2' | 'fp3':
-                return session.upper()
-            case 'race':  # Some simple mapping
-                return 'R'
-            case 'sprint' | 'sprint_race' | 'sprint race':
-                return 'SR'
-            case _:
-                raise ValueError(f'Invalid session: {session}. Must be one of: "R", "Q1", "Q2",'
-                                 f'"Q3", "SR", "SQ1", "SQ2", "SQ3", "FP1", "FP2", "FP3"')
+# class ValidatorMixin:
+#     @field_validator('session')
+#     @classmethod
+#     def clean_session(cls, session: str) -> str:
+#         match session.lower().strip():
+#             case 'r' | 'q1' | 'q2' | 'q3' | 'sr' | 'sq1' | 'sq2' | 'sq3' | 'fp1' | 'fp2' | 'fp3':
+#                 return session.upper()
+#             case 'race':  # Some simple mapping
+#                 return 'R'
+#             case 'sprint' | 'sprint_race' | 'sprint race':
+#                 return 'SR'
+#             case _:
+#                 raise ValueError(f'Invalid session: {session}. Must be one of: "R", "Q1", "Q2",'
+#                                  f'"Q3", "SR", "SQ1", "SQ2", "SQ3", "FP1", "FP2", "FP3"')
 
-class PitStopForeignKeys(data_import.PitStopForeignKeys, ValidatorMixin):
-    pass
-class LapForeignKeys(data_import.PitStopForeignKeys, ValidatorMixin):
-    pass
+# class PitStopForeignKeys(data_import.PitStopForeignKeys, ValidatorMixin):
+#     pass
+# class LapForeignKeys(data_import.PitStopForeignKeys, ValidatorMixin):
+#     pass
 
-class RoundEntryForeignKeys(data_import.RoundEntryForeignKeys):
-    @model_validator(mode='before')
-    def get_team_reference(self) -> Self:
-        if self['year'] in TEAMS:
-            if self['team_reference'] in TEAMS[self['year']]:
-                self['team_reference'] = TEAMS[self['year']][self['team_reference']]
-                return self
-            else:
-                raise ValueError(f"team {self['team_reference']} not found in year "
-                                 f"{self['year']}'s team name mapping. Available teams: "
-                                 f"{TEAMS[self['year']].keys()}")
-        else:
-            raise ValueError(f"year {self['year']} not found in team name mapping. Available "
-                             f'years: {TEAMS.keys()}')
+# class RoundEntryForeignKeys(data_import.RoundEntryForeignKeys):
+#     @model_validator(mode='before')
+#     def get_team_reference(self) -> Self:
+#         if self['year'] in TEAMS:
+#             if self['team_reference'] in TEAMS[self['year']]:
+#                 self['team_reference'] = TEAMS[self['year']][self['team_reference']]
+#                 return self
+#             else:
+#                 raise ValueError(f"team {self['team_reference']} not found in year "
+#                                  f"{self['year']}'s team name mapping. Available teams: "
+#                                  f"{TEAMS[self['year']].keys()}")
+#         else:
+#             raise ValueError(f"year {self['year']} not found in team name mapping. Available "
+#                              f'years: {TEAMS.keys()}')
 
-    @model_validator(mode='before')
-    def get_driver_name(self) -> Self:
-        if self['year'] in DRIVERS:
-            if self['driver_reference'] in DRIVERS[self['year']]:
-                self['driver_reference'] = DRIVERS[self['year']][self['driver_reference']]
-                return self
-            else:
-                raise ValueError(f"driver {self['driver_reference']} not found in year "
-                                 f"{self['year']}'s driver name mapping. Available drivers: "
-                                 f"{DRIVERS[self['year']].keys()}")
-        else:
-            raise ValueError(f"year {self['year']} not found in driver name mapping. Available "
-                             f'years: {DRIVERS.keys()}')
+#     @model_validator(mode='before')
+#     def get_driver_name(self) -> Self:
+#         if self['year'] in DRIVERS:
+#             if self['driver_reference'] in DRIVERS[self['year']]:
+#                 self['driver_reference'] = DRIVERS[self['year']][self['driver_reference']]
+#                 return self
+#             else:
+#                 raise ValueError(f"driver {self['driver_reference']} not found in year "
+#                                  f"{self['year']}'s driver name mapping. Available drivers: "
+#                                  f"{DRIVERS[self['year']].keys()}")
+#         else:
+#             raise ValueError(f"year {self['year']} not found in driver name mapping. Available "
+#                              f'years: {DRIVERS.keys()}')
 
 class EntryListParser:
     def __init__(
@@ -632,16 +632,16 @@ class RaceParser:
 
         def to_json() -> list[dict]:
             return df.apply(
-                lambda x: ClassificationData(
+                lambda x: SessionEntryImport(
                     object_type="SessionEntry",
-                    foreign_keys=SessionEntry(
+                    foreign_keys=SessionEntryForeignKeys(
                         year=self.year,
                         round=self.round_no,
                         session=self.session,
                         car_number=x.car_no
                     ),
                     objects=[
-                        Classification(
+                        SessionEntryObject(
                             position=x.finishing_position,
                             is_classified=x.is_classified,
                             status=x.finishing_status,
@@ -1224,7 +1224,7 @@ class RaceParser:
             )
             temp = temp.groupby('car_no')[['lap']].agg(list).reset_index()
             temp['session_entry'] = temp.car_no.map(
-                lambda x: SessionEntry(
+                lambda x: SessionEntryForeignKeys(
                     year=self.year,
                     round=self.round_no,
                     session='R' if self.session == 'race' else 'SR',
@@ -1632,16 +1632,16 @@ class QualifyingParser:
                 temp = temp.sort_values(by=['is_dsq', f'Q{q}', 'original_order'])
                 temp['position'] = range(1, len(temp) + 1)
                 temp['classification'] = temp.apply(
-                    lambda x: QualiClassificationData(
+                    lambda x: SessionEntryImport(
                         object_type="SessionEntry",
-                        foreign_keys=SessionEntry(
+                        foreign_keys=SessionEntryForeignKeys(
                             year=self.year,
                             round=self.round_no,
                             session=f'Q{q}' if self.session == 'quali' else f'SQ{q}',
                             car_number=x.NO
                         ),
                         objects=[
-                            QualiClassification(
+                            SessionEntryObject(
                                 position=x.position,
                                 is_classified=(x.finishing_status == 0)
                             )
@@ -1946,7 +1946,7 @@ class QualifyingParser:
                 )
                 temp = temp.groupby('car_no')[['lap']].agg(list).reset_index()
                 temp['session_entry'] = temp['car_no'].map(
-                    lambda x: SessionEntry(
+                    lambda x: SessionEntryForeignKeys(
                         year=self.year,
                         round=self.round_no,
                         session=f'Q{q}' if self.session == 'quali' else f'SQ{q}',

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -2,25 +2,24 @@
 import os
 import pickle
 import re
-from typing import Literal, get_args
 import warnings
+from typing import Literal, get_args
 
 import numpy as np
 import pandas as pd
-from pydantic import ValidationError
 import pymupdf
+from pydantic import ValidationError
 
 from ._constants import QUALI_DRIVERS
-from .models.classification import(
-    SessionEntryObject,
+from .models.classification import (
     SessionEntryImport,
+    SessionEntryObject,
 )
-from .models.driver import RoundEntryObject, RoundEntryImport
+from .models.driver import RoundEntryImport, RoundEntryObject
 from .models.foreign_key import PitStopForeignKeys, RoundEntry, SessionEntryForeignKeys
-from .models.lap import LapObject, LapImport
-from .models.pit_stop import PitStopObject, PitStopData
+from .models.lap import LapImport, LapObject
+from .models.pit_stop import PitStopData, PitStopObject
 from .utils import Page, duration_to_millisecond, time_to_timedelta
-
 
 pd.set_option('future.no_silent_downcasting', True)
 

--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -9,23 +9,17 @@ import numpy as np
 import pandas as pd
 from pydantic import ValidationError
 import pymupdf
-from jolpica.schemas import data_import
-from typing_extensions import Self
 
 from ._constants import QUALI_DRIVERS
 from .models.classification import(
     SessionEntryObject,
     SessionEntryImport,
-    QualiClassification,
-    QualiClassificationData
 )
-from .models.driver import Driver, DriverData
-from .models.foreign_key import PitStopEntry, RoundEntry, SessionEntryForeignKeys
-from .models.lap import Lap, LapData, QualiLap
-from .models.pit_stop import PitStop, PitStopData
+from .models.driver import RoundEntryObject, RoundEntryImport
+from .models.foreign_key import PitStopForeignKeys, RoundEntry, SessionEntryForeignKeys
+from .models.lap import LapObject, LapImport
+from .models.pit_stop import PitStopObject, PitStopData
 from .utils import Page, duration_to_millisecond, time_to_timedelta
-from pydantic import BaseModel, ConfigDict, PositiveInt, field_validator, model_validator
-from ._constants import DRIVERS, TEAMS
 
 
 pd.set_option('future.no_silent_downcasting', True)
@@ -33,64 +27,6 @@ pd.set_option('future.no_silent_downcasting', True)
 
 RaceSessionT = Literal['race', 'sprint']
 QualiSessionT = Literal['quali', 'sprint_quali']
-
-# class SessionEntryObjectJson(data_import.SessionEntryObject):
-#     time: dict[str, str | int]
-
-# class PitStopObjectJson(data_import.PitStopObject):
-#     duration: dict[str, str | int]
-
-# class LapObjectJson(data_import.LapObject):
-#     time: dict[str, str | int]
-
-# class ValidatorMixin:
-#     @field_validator('session')
-#     @classmethod
-#     def clean_session(cls, session: str) -> str:
-#         match session.lower().strip():
-#             case 'r' | 'q1' | 'q2' | 'q3' | 'sr' | 'sq1' | 'sq2' | 'sq3' | 'fp1' | 'fp2' | 'fp3':
-#                 return session.upper()
-#             case 'race':  # Some simple mapping
-#                 return 'R'
-#             case 'sprint' | 'sprint_race' | 'sprint race':
-#                 return 'SR'
-#             case _:
-#                 raise ValueError(f'Invalid session: {session}. Must be one of: "R", "Q1", "Q2",'
-#                                  f'"Q3", "SR", "SQ1", "SQ2", "SQ3", "FP1", "FP2", "FP3"')
-
-# class PitStopForeignKeys(data_import.PitStopForeignKeys, ValidatorMixin):
-#     pass
-# class LapForeignKeys(data_import.PitStopForeignKeys, ValidatorMixin):
-#     pass
-
-# class RoundEntryForeignKeys(data_import.RoundEntryForeignKeys):
-#     @model_validator(mode='before')
-#     def get_team_reference(self) -> Self:
-#         if self['year'] in TEAMS:
-#             if self['team_reference'] in TEAMS[self['year']]:
-#                 self['team_reference'] = TEAMS[self['year']][self['team_reference']]
-#                 return self
-#             else:
-#                 raise ValueError(f"team {self['team_reference']} not found in year "
-#                                  f"{self['year']}'s team name mapping. Available teams: "
-#                                  f"{TEAMS[self['year']].keys()}")
-#         else:
-#             raise ValueError(f"year {self['year']} not found in team name mapping. Available "
-#                              f'years: {TEAMS.keys()}')
-
-#     @model_validator(mode='before')
-#     def get_driver_name(self) -> Self:
-#         if self['year'] in DRIVERS:
-#             if self['driver_reference'] in DRIVERS[self['year']]:
-#                 self['driver_reference'] = DRIVERS[self['year']][self['driver_reference']]
-#                 return self
-#             else:
-#                 raise ValueError(f"driver {self['driver_reference']} not found in year "
-#                                  f"{self['year']}'s driver name mapping. Available drivers: "
-#                                  f"{DRIVERS[self['year']].keys()}")
-#         else:
-#             raise ValueError(f"year {self['year']} not found in driver name mapping. Available "
-#                              f'years: {DRIVERS.keys()}')
 
 class EntryListParser:
     def __init__(
@@ -325,7 +261,7 @@ class EntryListParser:
             drivers = []
             for x in df.itertuples():
                 try:
-                    drivers.append(DriverData(
+                    drivers.append(RoundEntryImport(
                             object_type="RoundEntry",
                             foreign_keys=RoundEntry(
                                 year=self.year,
@@ -334,7 +270,7 @@ class EntryListParser:
                                 driver_reference=x.driver
                             ),
                             objects=[
-                                Driver(
+                                RoundEntryObject(
                                     car_number=x.car_no
                                 )
                             ]
@@ -1214,7 +1150,7 @@ class RaceParser:
         def to_json() -> list[dict]:
             temp = df.copy()
             temp.lap = temp.apply(
-                lambda x: Lap(
+                lambda x: LapObject(
                     number=x.lap,
                     position=x.position,
                     time=duration_to_millisecond(x.lap_time),
@@ -1232,7 +1168,7 @@ class RaceParser:
                 )
             )
             return temp.apply(
-                lambda x: LapData(
+                lambda x: LapImport(
                     object_type="Lap",
                     foreign_keys=x.session_entry,
                     objects=x.lap
@@ -1936,7 +1872,7 @@ class QualifyingParser:
             for q in [1, 2, 3]:
                 temp = lap_times[lap_times.Q == q].copy()
                 temp['lap'] = temp.apply(
-                    lambda x: QualiLap(
+                    lambda x: LapObject(
                         number=x.lap_no,
                         time=x.lap_time,
                         is_deleted=x.lap_time_deleted,
@@ -1954,7 +1890,7 @@ class QualifyingParser:
                     )
                 )
                 temp['lap_data'] = temp.apply(
-                    lambda x: LapData(
+                    lambda x: LapImport(
                         object_type="Lap",
                         foreign_keys=x['session_entry'],
                         objects=x['lap']
@@ -2141,7 +2077,7 @@ class PitStopParser:
         def to_json() -> list[dict]:
             pit_stop = df.copy()
             pit_stop['pit_stop'] = pit_stop.apply(
-                lambda x: PitStop(
+                lambda x: PitStopObject(
                     number=x.stop_no,
                     duration=duration_to_millisecond(x.duration),
                     local_timestamp=x.local_time
@@ -2149,7 +2085,7 @@ class PitStopParser:
                 axis=1
             )
             pit_stop['entry'] = pit_stop.apply(
-                lambda x: PitStopEntry(
+                lambda x: PitStopForeignKeys(
                     year=self.year,
                     round=self.round_no,
                     session=self.session if self.session == 'race' else 'SR',

--- a/fiadoc/tests/fixtures/2023_13_race_pit_stop.json
+++ b/fiadoc/tests/fixtures/2023_13_race_pit_stop.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -20,7 +20,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -40,7 +40,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -60,7 +60,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -80,7 +80,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -100,7 +100,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -120,7 +120,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -140,7 +140,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -160,7 +160,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -180,7 +180,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -200,7 +200,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -220,7 +220,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -240,7 +240,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -260,7 +260,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -280,7 +280,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -300,7 +300,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -320,7 +320,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -340,7 +340,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -360,7 +360,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -380,7 +380,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -400,7 +400,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -420,7 +420,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -440,7 +440,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -460,7 +460,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -480,7 +480,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -500,7 +500,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -520,7 +520,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -540,7 +540,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -560,7 +560,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -580,7 +580,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -600,7 +600,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -620,7 +620,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -640,7 +640,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -660,7 +660,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -680,7 +680,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -700,7 +700,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -720,7 +720,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -740,7 +740,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -760,7 +760,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -780,7 +780,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -800,7 +800,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -820,7 +820,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -840,7 +840,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -860,7 +860,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -880,7 +880,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -900,7 +900,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -920,7 +920,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -940,7 +940,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -960,7 +960,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -980,7 +980,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1000,7 +1000,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1020,7 +1020,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1040,7 +1040,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1060,7 +1060,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1080,7 +1080,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1100,7 +1100,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1120,7 +1120,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1140,7 +1140,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1160,7 +1160,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1180,7 +1180,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1200,7 +1200,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1220,7 +1220,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1240,7 +1240,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1260,7 +1260,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1280,7 +1280,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1300,7 +1300,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1320,7 +1320,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1340,7 +1340,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1360,7 +1360,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1380,7 +1380,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1400,7 +1400,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1420,7 +1420,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1440,7 +1440,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1460,7 +1460,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1480,7 +1480,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1500,7 +1500,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1520,7 +1520,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1540,7 +1540,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1560,7 +1560,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1580,7 +1580,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1600,7 +1600,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1620,7 +1620,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1640,7 +1640,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1660,7 +1660,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1680,7 +1680,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1700,7 +1700,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1720,7 +1720,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1740,7 +1740,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1760,7 +1760,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1780,7 +1780,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1800,7 +1800,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1820,7 +1820,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1840,7 +1840,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1860,7 +1860,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1880,7 +1880,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1900,7 +1900,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1920,7 +1920,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1940,7 +1940,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1960,7 +1960,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -1980,7 +1980,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,
@@ -2000,7 +2000,7 @@
         ]
     },
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2023,
             "round": 13,

--- a/fiadoc/tests/fixtures/2023_18_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -61,7 +61,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -101,7 +101,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -141,7 +141,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -181,7 +181,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -220,7 +220,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -259,7 +259,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -298,7 +298,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -337,7 +337,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -376,7 +376,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -415,7 +415,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -454,7 +454,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -493,7 +493,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -525,7 +525,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -557,7 +557,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -596,7 +596,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -635,7 +635,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -674,7 +674,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -734,7 +734,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -766,7 +766,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -798,7 +798,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -837,7 +837,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -876,7 +876,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -908,7 +908,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -968,7 +968,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1007,7 +1007,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1067,7 +1067,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1106,7 +1106,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1145,7 +1145,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1184,7 +1184,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1216,7 +1216,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1255,7 +1255,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1308,7 +1308,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1347,7 +1347,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1386,7 +1386,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1425,7 +1425,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1478,7 +1478,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1517,7 +1517,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1549,7 +1549,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1588,7 +1588,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1627,7 +1627,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1680,7 +1680,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1733,7 +1733,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1772,7 +1772,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1811,7 +1811,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,

--- a/fiadoc/tests/fixtures/2023_18_race_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_race_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -515,7 +515,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1030,7 +1030,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1545,7 +1545,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2060,7 +2060,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2575,7 +2575,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -3090,7 +3090,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -3605,7 +3605,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -4120,7 +4120,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -4635,7 +4635,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -5150,7 +5150,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -5665,7 +5665,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -6180,7 +6180,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -6686,7 +6686,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -7192,7 +7192,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -7698,7 +7698,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -8150,7 +8150,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -8251,7 +8251,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -8316,7 +8316,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -8831,7 +8831,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,

--- a/fiadoc/tests/fixtures/2023_18_sprint_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_sprint_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -173,7 +173,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -346,7 +346,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -519,7 +519,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -692,7 +692,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -865,7 +865,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1038,7 +1038,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1211,7 +1211,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1384,7 +1384,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1557,7 +1557,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1730,7 +1730,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1903,7 +1903,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2076,7 +2076,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2249,7 +2249,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2395,7 +2395,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2568,7 +2568,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2741,7 +2741,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2914,7 +2914,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -3087,7 +3087,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -3260,7 +3260,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,

--- a/fiadoc/tests/fixtures/2023_18_sprint_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_18_sprint_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -29,7 +29,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -85,7 +85,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -141,7 +141,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -206,7 +206,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -262,7 +262,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -309,7 +309,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -365,7 +365,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -421,7 +421,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -477,7 +477,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -533,7 +533,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -580,7 +580,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -636,7 +636,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -683,7 +683,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -739,7 +739,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -795,7 +795,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -851,7 +851,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -907,7 +907,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -963,7 +963,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1019,7 +1019,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1084,7 +1084,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1140,7 +1140,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1178,7 +1178,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1234,7 +1234,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1272,7 +1272,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1337,7 +1337,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1375,7 +1375,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1431,7 +1431,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1487,7 +1487,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1525,7 +1525,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1590,7 +1590,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1628,7 +1628,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1666,7 +1666,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1722,7 +1722,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1760,7 +1760,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1816,7 +1816,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1854,7 +1854,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1892,7 +1892,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1921,7 +1921,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1950,7 +1950,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -1988,7 +1988,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2017,7 +2017,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2055,7 +2055,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2093,7 +2093,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,
@@ -2122,7 +2122,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 18,

--- a/fiadoc/tests/fixtures/2023_7_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_7_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -83,7 +83,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -139,7 +139,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -231,7 +231,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -314,7 +314,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -406,7 +406,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -489,7 +489,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -572,7 +572,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -673,7 +673,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -747,7 +747,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -839,7 +839,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -940,7 +940,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1005,7 +1005,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1097,7 +1097,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1180,7 +1180,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1263,7 +1263,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1364,7 +1364,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1456,7 +1456,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1557,7 +1557,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1640,7 +1640,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1714,7 +1714,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1779,7 +1779,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1844,7 +1844,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1909,7 +1909,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -1974,7 +1974,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2039,7 +2039,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2104,7 +2104,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2160,7 +2160,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2234,7 +2234,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2290,7 +2290,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2355,7 +2355,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2420,7 +2420,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2485,7 +2485,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2550,7 +2550,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2615,7 +2615,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2680,7 +2680,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2718,7 +2718,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2765,7 +2765,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2812,7 +2812,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2832,7 +2832,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2879,7 +2879,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2908,7 +2908,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -2955,7 +2955,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -3002,7 +3002,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,
@@ -3049,7 +3049,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 7,

--- a/fiadoc/tests/fixtures/2023_9_race_lap_times.json
+++ b/fiadoc/tests/fixtures/2023_9_race_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -650,7 +650,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -1291,7 +1291,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -1941,7 +1941,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -2591,7 +2591,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -3241,7 +3241,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -3891,7 +3891,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -4541,7 +4541,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -5191,7 +5191,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -5832,7 +5832,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -6473,7 +6473,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -7114,7 +7114,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -7764,7 +7764,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -8405,7 +8405,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -8524,7 +8524,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -9165,7 +9165,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -9815,7 +9815,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -10465,7 +10465,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -11115,7 +11115,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,
@@ -11756,7 +11756,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2023,
             "round": 9,

--- a/fiadoc/tests/fixtures/2024_05_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_05_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -56,7 +56,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -121,7 +121,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -177,7 +177,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -233,7 +233,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -316,7 +316,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -381,7 +381,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -410,7 +410,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -484,7 +484,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -540,7 +540,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -596,7 +596,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -679,7 +679,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -753,7 +753,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -827,7 +827,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -910,7 +910,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -993,7 +993,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1049,7 +1049,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1105,7 +1105,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1188,7 +1188,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1244,7 +1244,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1291,7 +1291,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1356,7 +1356,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1412,7 +1412,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1450,7 +1450,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1506,7 +1506,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1571,7 +1571,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1636,7 +1636,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1701,7 +1701,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1757,7 +1757,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1813,7 +1813,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1878,7 +1878,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1934,7 +1934,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -1990,7 +1990,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2046,7 +2046,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2111,7 +2111,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2167,7 +2167,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2223,7 +2223,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2270,7 +2270,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2317,7 +2317,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2373,7 +2373,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2420,7 +2420,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2485,7 +2485,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2541,7 +2541,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2588,7 +2588,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,
@@ -2608,7 +2608,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 5,

--- a/fiadoc/tests/fixtures/2024_10_race_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_10_race_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -605,7 +605,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -1192,7 +1192,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -1788,7 +1788,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -2393,7 +2393,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -2998,7 +2998,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -3603,7 +3603,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -4199,7 +4199,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -4804,7 +4804,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -5400,7 +5400,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -5996,7 +5996,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -6592,7 +6592,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -7188,7 +7188,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -7784,7 +7784,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -8389,7 +8389,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -8994,7 +8994,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -9599,7 +9599,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -10204,7 +10204,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -10809,7 +10809,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,
@@ -11405,7 +11405,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 10,

--- a/fiadoc/tests/fixtures/2024_21_sprint_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_21_sprint_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -56,7 +56,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -112,7 +112,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -168,7 +168,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -224,7 +224,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -280,7 +280,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -363,7 +363,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -419,7 +419,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -475,7 +475,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -531,7 +531,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -578,7 +578,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -625,7 +625,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -672,7 +672,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -728,7 +728,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -784,7 +784,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -840,7 +840,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -896,7 +896,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -979,7 +979,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1035,7 +1035,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1091,7 +1091,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1129,7 +1129,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1167,7 +1167,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1205,7 +1205,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1270,7 +1270,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1317,7 +1317,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1382,7 +1382,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1420,7 +1420,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1458,7 +1458,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1496,7 +1496,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1534,7 +1534,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1608,7 +1608,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1646,7 +1646,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1684,7 +1684,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1749,7 +1749,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1814,7 +1814,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1879,7 +1879,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1917,7 +1917,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -1973,7 +1973,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2011,7 +2011,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2049,7 +2049,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2087,7 +2087,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2125,7 +2125,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2163,7 +2163,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2192,7 +2192,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,
@@ -2221,7 +2221,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 21,

--- a/fiadoc/tests/fixtures/2024_22_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_22_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -127,7 +127,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -166,7 +166,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -226,7 +226,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -293,7 +293,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -339,7 +339,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -406,7 +406,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -452,7 +452,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -498,7 +498,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -558,7 +558,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -611,7 +611,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -650,7 +650,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -710,7 +710,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -756,7 +756,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -795,7 +795,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -841,7 +841,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -880,7 +880,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -919,7 +919,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -986,7 +986,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1039,7 +1039,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1078,7 +1078,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1131,7 +1131,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1170,7 +1170,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1209,7 +1209,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1248,7 +1248,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1287,7 +1287,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1319,7 +1319,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1386,7 +1386,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1453,7 +1453,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1485,7 +1485,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1552,7 +1552,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1605,7 +1605,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1644,7 +1644,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1690,7 +1690,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1757,7 +1757,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1803,7 +1803,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1870,7 +1870,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1902,7 +1902,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -1969,7 +1969,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -2015,7 +2015,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -2089,7 +2089,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -2149,7 +2149,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -2216,7 +2216,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,
@@ -2283,7 +2283,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 22,

--- a/fiadoc/tests/fixtures/2024_2_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_2_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -56,7 +56,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -139,7 +139,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -195,7 +195,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -269,7 +269,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -352,7 +352,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -408,7 +408,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -482,7 +482,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -556,7 +556,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -630,7 +630,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -704,7 +704,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -760,7 +760,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -834,7 +834,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -854,7 +854,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -928,7 +928,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1020,7 +1020,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1103,7 +1103,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1186,7 +1186,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1260,7 +1260,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1343,7 +1343,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1417,7 +1417,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1482,7 +1482,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1547,7 +1547,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1630,7 +1630,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1704,7 +1704,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1742,7 +1742,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1825,7 +1825,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1881,7 +1881,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -1964,7 +1964,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2029,7 +2029,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2103,7 +2103,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2123,7 +2123,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2206,7 +2206,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2298,7 +2298,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2390,7 +2390,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2473,7 +2473,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2538,7 +2538,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2594,7 +2594,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2650,7 +2650,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2715,7 +2715,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2780,7 +2780,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2845,7 +2845,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2901,7 +2901,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -2957,7 +2957,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,
@@ -3004,7 +3004,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 2,

--- a/fiadoc/tests/fixtures/2024_3_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_3_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -83,7 +83,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -139,7 +139,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -204,7 +204,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -296,7 +296,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -379,7 +379,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -435,7 +435,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -491,7 +491,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -574,7 +574,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -639,7 +639,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -695,7 +695,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -778,7 +778,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -861,7 +861,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -926,7 +926,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1027,7 +1027,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1110,7 +1110,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1166,7 +1166,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1249,7 +1249,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1332,7 +1332,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1397,7 +1397,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1462,7 +1462,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1527,7 +1527,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1601,7 +1601,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1693,7 +1693,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1785,7 +1785,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1877,7 +1877,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -1942,7 +1942,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2007,7 +2007,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2063,7 +2063,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2155,7 +2155,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2220,7 +2220,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2285,7 +2285,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2359,7 +2359,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2424,7 +2424,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2480,7 +2480,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2545,7 +2545,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2610,7 +2610,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2675,7 +2675,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2740,7 +2740,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2796,7 +2796,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2852,7 +2852,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2917,7 +2917,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -2982,7 +2982,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,
@@ -3056,7 +3056,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 3,

--- a/fiadoc/tests/fixtures/2024_8_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_8_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -110,7 +110,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -220,7 +220,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -330,7 +330,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -449,7 +449,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -559,7 +559,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -669,7 +669,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -770,7 +770,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -862,7 +862,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -963,7 +963,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1064,7 +1064,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1156,7 +1156,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1275,7 +1275,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1376,7 +1376,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1468,7 +1468,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1578,7 +1578,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1688,7 +1688,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1789,7 +1789,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1899,7 +1899,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2000,7 +2000,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2110,7 +2110,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2202,7 +2202,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2294,7 +2294,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2377,7 +2377,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2478,7 +2478,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2579,7 +2579,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2644,7 +2644,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2718,7 +2718,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2810,7 +2810,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2911,7 +2911,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3012,7 +3012,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3095,7 +3095,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3196,7 +3196,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3288,7 +3288,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3380,7 +3380,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3445,7 +3445,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3519,7 +3519,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3584,7 +3584,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3667,7 +3667,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3732,7 +3732,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3797,7 +3797,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3862,7 +3862,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3927,7 +3927,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -4010,7 +4010,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -4084,7 +4084,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,

--- a/fiadoc/tests/fixtures/2024_8_race_lap_times.json
+++ b/fiadoc/tests/fixtures/2024_8_race_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -713,7 +713,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -1408,7 +1408,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2103,7 +2103,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -2816,7 +2816,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -3520,7 +3520,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -4215,7 +4215,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -4928,7 +4928,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -5623,7 +5623,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -6327,7 +6327,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -7031,7 +7031,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -7726,7 +7726,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -8439,7 +8439,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -9152,7 +9152,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -9865,7 +9865,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,
@@ -10560,7 +10560,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2024,
             "round": 8,

--- a/fiadoc/tests/fixtures/2025_1_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2025_1_quali_lap_times.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -47,7 +47,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -121,7 +121,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -195,7 +195,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -251,7 +251,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -334,7 +334,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -417,7 +417,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -500,7 +500,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -574,7 +574,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -639,7 +639,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -722,7 +722,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -778,7 +778,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -861,7 +861,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -944,7 +944,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1009,7 +1009,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1083,7 +1083,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1166,7 +1166,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1249,7 +1249,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1332,7 +1332,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1397,7 +1397,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1462,7 +1462,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1527,7 +1527,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1583,7 +1583,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1648,7 +1648,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1713,7 +1713,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1778,7 +1778,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1834,7 +1834,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1917,7 +1917,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -1982,7 +1982,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2047,7 +2047,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2112,7 +2112,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2195,7 +2195,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2260,7 +2260,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2325,7 +2325,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2381,7 +2381,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2446,7 +2446,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2511,7 +2511,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2576,7 +2576,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2632,7 +2632,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2697,7 +2697,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2762,7 +2762,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2827,7 +2827,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2892,7 +2892,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,
@@ -2948,7 +2948,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 1,

--- a/fiadoc/tests/fixtures/2025_2_sprint_pit_stop.json
+++ b/fiadoc/tests/fixtures/2025_2_sprint_pit_stop.json
@@ -1,6 +1,6 @@
 [
     {
-        "object_type": "pit_stop",
+        "object_type": "PitStop",
         "foreign_keys": {
             "year": 2025,
             "round": 2,

--- a/fiadoc/tests/fixtures/2025_2_sprint_quali_lap_times.json
+++ b/fiadoc/tests/fixtures/2025_2_sprint_quali_lap_times.json
@@ -1,6 +1,6 @@
  [
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -56,7 +56,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -112,7 +112,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -168,7 +168,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -224,7 +224,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -280,7 +280,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -336,7 +336,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -401,7 +401,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -448,7 +448,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -504,7 +504,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -560,7 +560,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -616,7 +616,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -672,7 +672,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -728,7 +728,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -775,7 +775,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -831,7 +831,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -887,7 +887,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -943,7 +943,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1017,7 +1017,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1055,7 +1055,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1111,7 +1111,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1149,7 +1149,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1187,7 +1187,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1252,7 +1252,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1281,7 +1281,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1355,7 +1355,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1393,7 +1393,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1458,7 +1458,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1496,7 +1496,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1534,7 +1534,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1581,7 +1581,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1646,7 +1646,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1693,7 +1693,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1767,7 +1767,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1814,7 +1814,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1852,7 +1852,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1890,7 +1890,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1937,7 +1937,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -1975,7 +1975,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -2013,7 +2013,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -2051,7 +2051,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -2089,7 +2089,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -2136,7 +2136,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -2174,7 +2174,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,
@@ -2212,7 +2212,7 @@
         ]
     },
     {
-        "object_type": "lap",
+        "object_type": "Lap",
         "foreign_keys": {
             "year": 2025,
             "round": 2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,19 +8,23 @@ authors = [
 description = "Parse FIA PDF documents to get race data"
 readme = "README.md"
 
-requires-python = ">=3.10,<3.13"  # 3.10 should work but older versions may also be fine
+requires-python = ">=3.12,<3.13"  # jolpica-schemas requires 3.12+
 dependencies = [
   "camelot-py[base]>=1.0.0,<2.0.0",
   "matplotlib>=3.4.0,<4.0.0",
   "pandas>=2.0.0,<3.0.0",
   "pydantic>=2.0.0,<3.0.0",
   "pymupdf==1.25.1",  # Seems related to pymupdf/PyMuPDF#4206? Check `assert option in formats`
-  "requests>=2.28.0,<3.0.0"
+  "requests>=2.28.0,<3.0.0",
+  "jolpica-schemas @ git+https://github.com/jolpica/jolpica-f1@71f12b1c9637aa838926abcb6f4840fbfac4d87c#egg=jolpica-schemas&subdirectory=jolpica/schemas",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 ignore-vcs = true


### PR DESCRIPTION
Install jolpica-schemas package and use it as base for all models.

Fix object_type of PitStop & Lap

Also changed all `model_dump` to exclude unset arguments, as not doing this would result in null values in the json, which the import endpoint would interpret as overriding the existing value with null