### PR TITLE
Fix classified driver with DNF is listed with incorrect finishing status

### DIFF
--- a/fiadoc/parser.py
+++ b/fiadoc/parser.py
@@ -533,6 +533,7 @@ class RaceParser:
 
         # Clean up finishing status, e.g. is lapped? Is DSQ?
         df.loc[df.gap.fillna('').str.contains('LAP', regex=False), 'finishing_status'] = 1
+        df.loc[(df.finishing_position == 'DNF') | (df.gap == 'DNF'), 'finishing_status'] = 11
         df.loc[(df.finishing_position == 'DQ') | (df.gap == 'DQ'), 'finishing_status'] = 20
         df.loc[(df.finishing_position == 'DNS') | (df.gap == 'DNS'), 'finishing_status'] = 30
         # TODO: clean up the coding


### PR DESCRIPTION
In 2024 round 3 (Australian GP), Russel crashed one lap before the end. He therefore is classified (sufficient race distance covered) but DNFed, so the finishing status should be status code ``11``. But he is listed with status code ``0`` for "Finished".
DNF was previously only set for not qualified drivers. DQ and DNS on the other hand were checked for all drivers. This might be a simple small oversight then, and I treated/fixed it as such. It didn't look like there are more complications.

The test setup currently isn't really set up for testing such special cases. Therefore, I haven't added a test. If you want me to add a test for this, let me know how this should be done best.

xref https://github.com/jolpica/jolpica-f1/issues/223