### PR TITLE
refactor: move `_parse_table_by_grid` to `BaseParser`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,6 @@ ignore = [
   "PLR0913",
   "PLR1714",  # Write out all comparisons for readability
   "UP009",    # UTF-8 encoding
-  "UP007"     # I prefer `Optional[xxx]` over xxx | None
+  "UP007",    # I prefer `Optional[xxx]` over xxx | None
+  "UP045"     # I prefer `Optional[xxx]` over xxx | None
 ]


### PR DESCRIPTION
many parsers share the same method `_parse_table_by_grid`. So now I created a base class with this method, so all parsers can inherit the method