### PR TITLE
perf: skip unnecessary cols.; cache pixmap; avoid OCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ training/labelling/static/
 
 # Mac shit
 .DS_Store
+
+# OCR debug output
+debug_ocr/

--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -188,19 +188,41 @@ REGULAR_DRIVERS = {
 DPI = 600
 
 # Expected cols. in the PDFs
+"""
+* required: must have cols. If any of these cols. are missing, then means the PDF/table
+            layout changes, and thus we can't parse
+* optional: we cover many years' PDFs, and some cols. are added while others are removed between
+            years. These col. changes don't affect the parsing, so we flag them as optional
+* to_parse: cols. we need to parse. Some required cols. can be skipped to save time, e.g. the
+            country flag col. in classification PDFs. This is different from required cols., as
+            we need all required cols. to make sure the table layout is what we expect, and among
+            these required cols., we only need to parse a subset of them and skip the rest
+"""
 EXPECTED_COLS: dict[str, dict[str, set | list]] = {
     'entry_list': {
         'required': {'no.', 'constructor'},
         'optional': {'tla', 'driver', 'nat', 'team'}
     },
-    'fp': {
+    'fp_classification': {
         'required': {'no', 'driver', 'nat', 'entrant', 'time', 'laps', 'gap', 'int', 'km/h',
                      'time of day'},
-        'optional': {}
+        'to_parse': {'no', 'time', 'laps', 'gap', 'int', 'km/h', 'time of day'}
+    },
+    'fp_lap_times': {
+        'required': {'no', 'time'},
+        'to_check_strikeout': {'time'}
+    },
+    'quali_lap_times': {
+        'required': {'no', 'time'},
+        'to_check_strikeout': {'time'}
+    },
+    'race_lap_times': {
+        'required': {'no', 'time'},
+        'to_check_strikeout': {'time'}
     },
     'race_sector_analysis': {
         'required': ['lap', 'time', 'km/h', 'time', 'km/h', 'time', 'km/h', 'time'],
-        'optional': {}
+        'to_check_strikeout': {'time'}
     }
 }
 

--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -233,6 +233,7 @@ EXPECTED_COLS: dict[str, dict[str, set | list]] = {
     },
     'race_sector_analysis': {
         'required': ['lap', 'time', 'km/h', 'time', 'km/h', 'time', 'km/h', 'time'],
+        'to_parse': {'lap', 'time'},
         'to_check_strikeout': {'time'}
     }
 }

--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -222,6 +222,11 @@ EXPECTED_COLS: dict[str, dict[str, set | list]] = {
         'to_parse': {'no', 'q1', 'q1_laps', 'q1_time', 'q2', 'q2_laps', 'q2_time', 'q3', 'q3_laps',
                      'q3_time'}
     },
+    'race_classification': {
+        'required': {'no', 'driver', 'nat', 'entrant', 'laps', 'time', 'gap', 'int', 'km/h',
+                     'fastest', 'on', 'pts'},
+        'to_parse': {'no', 'laps', 'time', 'gap', 'fastest', 'on', 'pts'}
+    },
     'race_lap_times': {
         'required': {'no', 'time'},
         'to_check_strikeout': {'time'}

--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -239,7 +239,7 @@ EXPECTED_COLS: dict[str, dict[str, set | list]] = {
     'pit_stop_summary': {
         'required': ['no', 'driver', 'entrant', 'lap', 'time of day', 'stop', 'duration',
                      'total time'],
-        'to_parse': {'no', 'lap', 'stop', 'time of day'}
+        'to_parse': {'no', 'lap', 'stop', 'time of day', 'duration'}
     }
 }
 

--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -216,6 +216,12 @@ EXPECTED_COLS: dict[str, dict[str, set | list]] = {
         'required': {'no', 'time'},
         'to_check_strikeout': {'time'}
     },
+    'quali_classification': {
+        'required': {'no', 'driver', 'nat', 'entrant', 'q1', 'q1_laps', 'q1_time', 'q2', 'q2_laps',
+                     'q2_time', 'q3', 'q3_laps', 'q3_time'},
+        'to_parse': {'no', 'q1', 'q1_laps', 'q1_time', 'q2', 'q2_laps', 'q2_time', 'q3', 'q3_laps',
+                     'q3_time'}
+    },
     'race_lap_times': {
         'required': {'no', 'time'},
         'to_check_strikeout': {'time'}

--- a/fiadoc/_constants.py
+++ b/fiadoc/_constants.py
@@ -235,6 +235,11 @@ EXPECTED_COLS: dict[str, dict[str, set | list]] = {
         'required': ['lap', 'time', 'km/h', 'time', 'km/h', 'time', 'km/h', 'time'],
         'to_parse': {'lap', 'time'},
         'to_check_strikeout': {'time'}
+    },
+    'pit_stop_summary': {
+        'required': ['no', 'driver', 'entrant', 'lap', 'time of day', 'stop', 'duration',
+                     'total time'],
+        'to_parse': {'no', 'lap', 'stop', 'time of day'}
     }
 }
 

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -7,6 +7,7 @@ import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import cache
+from pathlib import Path
 from string import printable
 from typing import Literal, Optional
 
@@ -51,6 +52,12 @@ rc = {'axes.facecolor': 'white',  # Remove background colour
       'figure.autolayout': True}
 plt.rcdefaults()
 plt.rcParams.update(rc)
+
+# Set to a directory path to save OCR input images for debugging. When None (default), no images
+# are saved. Usage: `page.OCR_DEBUG_DIR = 'debug_ocr'` before parsing.
+OCR_DEBUG_DIR: Optional[str | os.PathLike] = None
+_ocr_debug_counter: int = 0
+
 
 @cache
 def get_ocr_instance():
@@ -453,6 +460,18 @@ class Page:
 
         # Replace light grey pixel (RGB > 200) with white. This improves OCR quality a lot
         pixmap_arr[np.all(pixmap_arr >= 200, axis=2)] = 255  # noqa: PLR2004
+
+        # Save OCR input image for debugging if OCR_DEBUG_DIR is set
+        global _ocr_debug_counter  # noqa: PLW0603
+        if OCR_DEBUG_DIR is not None:
+            from PIL import Image
+            debug_dir = Path(OCR_DEBUG_DIR)
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            _ocr_debug_counter += 1
+            stem = Path(self.file).stem
+            page_num = self._pymupdf_page.number
+            fname = f'{_ocr_debug_counter:03d}_{stem}_p{page_num}'
+            Image.fromarray(pixmap_arr).save(debug_dir / f'{fname}.png')
 
         # OCR the clipped area
         match get_ocr_instance().predict(pixmap_arr):

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -170,21 +170,34 @@ class Page:
         if clip is None:
             raise ValueError('Without OCR we found nothing. And `clip` must be provided when '
                              'searching with OCR, to avoid very slow OCR and bad quality')
-        pixmap: pymupdf.Pixmap = self.get_pixmap(clip=clip, dpi=dpi, annots=False)
-        pixmap_arr: npt.NDArray[np.uint8] = (np.frombuffer(buffer=pixmap.samples_mv,
-                                                           dtype=np.uint8)
-                                             .reshape((pixmap.height, pixmap.width, 3))
-                                             .copy())
+        # Use cached pixmap array instead of creating a new pixmap each time
+        pixmap_arr: npt.NDArray[np.uint8] = self.get_pixmap_array(clip=clip, dpi=dpi, annots=False,
+                                                                  copy=True)
+
+        # Save OCR input image for debugging if OCR_DEBUG_DIR is set
+        global _ocr_debug_counter  # noqa: PLW0603
+        if OCR_DEBUG_DIR is not None:
+            from PIL import Image
+            debug_dir = Path(OCR_DEBUG_DIR)
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            _ocr_debug_counter += 1
+            stem = Path(self.file).stem
+            page_num = self._pymupdf_page.number
+            clip_str = f'c{clip[0]:.2f}_{clip[1]:.2f}_{clip[2]:.2f}_{clip[3]:.2f}'
+            fname = f'{_ocr_debug_counter:03d}_{stem}_p{page_num}_{clip_str}_search_for'
+            Image.fromarray(pixmap_arr).save(debug_dir / f'{fname}.png')
+
         ocr_results = get_ocr_instance().predict(pixmap_arr)[0]
         ocr_results = zip(ocr_results['rec_boxes'], ocr_results['rec_texts'])
 
         # Because of the DPI, the bounding boxes of texts after OCR may not be in the same
         # coordinate system as the original PDF page. Convert them back
+        pix_h, pix_w = pixmap_arr.shape[:2]
         ocr_results = [TextBlock(
             text=OCR_ERRORS.get(i[1], i[1]),
             bbox=self._transform_bbox(
                 bbox=tuple(i[0]),
-                from_page_bound=(0, 0, pixmap.width, pixmap.height),
+                from_page_bound=(0, 0, pix_w, pix_h),
                 to_page_bound=clip
             )
         ) for i in ocr_results]
@@ -488,6 +501,16 @@ class Page:
         # Also replace rows anywhere with black run > 80% of row width with all white pixels
         pixmap_arr[max_run > pix_w * 0.8, :] = 255
 
+        # Remove vertical table border lines (conservatively: only columns that are >95% black)
+        """
+        Similar to horizontal borders, vertical borders can occur between table columns. However,
+        a single black column could be the letter "l" (lowercase L) or "1" (one), so we only remove
+        columns that are >95% black to avoid removing text.
+        """
+        is_black_cols = np.all(pixmap_arr < 50, axis=2)
+        black_ratio_per_col = np.mean(is_black_cols, axis=0)
+        pixmap_arr[:, black_ratio_per_col > 0.95, :] = 255
+
         if np.sum(pixmap_arr < 50) < 10:  # noqa: PLR2004
             return []
 
@@ -503,7 +526,8 @@ class Page:
             _ocr_debug_counter += 1
             stem = Path(self.file).stem
             page_num = self._pymupdf_page.number
-            fname = f'{_ocr_debug_counter:03d}_{stem}_p{page_num}'
+            clip_str = f'c{clip[0]:.2f}_{clip[1]:.2f}_{clip[2]:.2f}_{clip[3]:.2f}'
+            fname = f'{_ocr_debug_counter:03d}_{stem}_p{page_num}_{clip_str}_get_text'
             Image.fromarray(pixmap_arr).save(debug_dir / f'{fname}.png')
 
         # OCR the clipped area

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -80,37 +80,45 @@ class Page:
         self.file = file           # The PDF file path. Mainly for debug purpose
         self.w = page.bound()[2]   # Width and height, for convenience
         self.h = page.bound()[3]
-        self._pixmap_cache: dict[tuple[int, int], npt.NDArray[np.uint8]] = {}
+        self._pixmap_cache: dict[tuple[int, int, bool], npt.NDArray[np.uint8]] = {}
 
-    def _get_full_page_pixmap(self, dpi: int) -> npt.NDArray[np.uint8]:
-        """Get the full-page pixmap at the given DPI and rotation, caching on first access"""
-        key = (dpi, self._pymupdf_page.rotation)
+    def _get_full_page_pixmap(self, dpi: int, annots: bool = True) -> npt.NDArray[np.uint8]:
+        """Get the full-page pixmap at the given DPI and rotation, caching on first access
+
+        :param dpi: The DPI of the pixmap
+        :param annots: Whether to include annotations. Default is `True`
+        """
+        key = (dpi, self._pymupdf_page.rotation, annots)
         if key not in self._pixmap_cache:
-            pixmap: pymupdf.Pixmap = self._pymupdf_page.get_pixmap(dpi=dpi)
-            self._pixmap_cache[key] = (
-                np.frombuffer(buffer=pixmap.samples_mv, dtype=np.uint8)
-                .reshape((pixmap.height, pixmap.width, 3))
-                .copy()
-            )
+            pixmap: pymupdf.Pixmap = self._pymupdf_page.get_pixmap(dpi=dpi, annots=annots)
+            self._pixmap_cache[key] = (np.frombuffer(buffer=pixmap.samples_mv, dtype=np.uint8)
+                                       .reshape((pixmap.height, pixmap.width, 3))
+                                       .copy())
         return self._pixmap_cache[key]
 
-    def get_pixmap_array(self, clip: Optional['BBox'] = None, dpi: int = DPI, copy: bool = False) \
-            -> npt.NDArray[np.uint8]:
+    def get_pixmap_array(
+            self,
+            clip: Optional['BBox'] =
+            None, dpi: int = DPI,
+            copy: bool = False,
+            annots: bool = True
+    ) -> npt.NDArray[np.uint8]:
         """Get page pixmap as a numpy array, sliced from a cached full-page render
 
-        The full page is rendered once per (DPI, rotation) pair and cached. Subsequent calls at the
-        same DPI and rotation return a slice of the cached array. There may be +/-1 px rounding
-        difference vs. a fresh `get_pixmap(clip=...)` call, which is negligible for structural
-        detection (white strips, grey/white rows, connected-component labelling, etc.).
+        The full page is rendered once per (DPI, rotation, annots) combination and cached.
+        Subsequent calls with the same parameters return a slice of the cached array. There may be
+        +/-1 px rounding difference vs. a fresh `.get_pixmap()` call, which is negligible for
+        structural detection (white strips, grey/white rows, connected-component labelling, etc.).
 
         :param clip: `(x0, y0, x1, y1)` in page coordinates. Default is `None`, i.e. full page
         :param dpi: The DPI of the pixmap. Default is 600
         :param copy: If `True`, return a deep copy so the caller can safely modify the array. If
                      `False` (default), return a view/slice of the cached array. It's faster, but
                      the caller **must not** modify it
+        :param annots: Whether to include annotations in the pixmap. Default is `True`
         :return: Pixmap in np.array of shape `(height, width, 3)`, dtype `uint8`
         """
-        arr = self._get_full_page_pixmap(dpi)
+        arr = self._get_full_page_pixmap(dpi, annots=annots)
 
         if clip:
             # Use current (possibly rotated) page bounds, not self.w/self.h which are always the
@@ -441,26 +449,45 @@ class Page:
         2. OCR quality can be really bad. It may say a short light grey line is "-", which breaks
            most of our parsing. So we try our best to avoid OCR-ing such areas
         """
-        pixmap: pymupdf.Pixmap = self.get_pixmap(clip=clip, dpi=dpi, annots=False)
-        pixmap_arr: npt.NDArray[np.uint8] = (np.frombuffer(buffer=pixmap.samples_mv,
-                                                           dtype=np.uint8)
-                                             .reshape((pixmap.height, pixmap.width, 3))
-                                             .copy())
-        """
-        To get `pixmap` into a numpy array of RGB pixels, we can use either `pixmap.samples` or
-        `pixmap.samples_mv`. The difference is that `pixmap.samples` returns a bytes object, i.e. a
-        copy of the original pixmap, while `pixmap.samples_mv` is a memory view/pointer to the
-        original pixmap. So the latter is significantly faster.
+        pixmap_arr: npt.NDArray[np.uint8] = self.get_pixmap_array(clip=clip,
+                                                                  dpi=dpi,
+                                                                  annots=False,
+                                                                  copy=True)
+        pix_h, pix_w = pixmap_arr.shape[:2]
 
-        However, we still must create a deep `.copy()`. Because PaddleOCR may process the input
-        image inplace, and we are working with a memory view, so during the OCR, the original
-        pixmap may be changed, leading to unexpected errors. I sometimes/very often get segfault
-        errors without the `.copy()`, but can't reproduce it consistently. For safety, always do a
-        copy here.
-
-        A quick benchmark shows that using `pixmap.samples_mv` + `.copy()` is 5x faster than using
-        `pixmap.samples`. This is why we reach the above code.
+        # Remove table border lines
         """
+        The clip area may include a horizontal table border at its top or bottom edge. Even if the
+        clip area has no black text, these black lines/pixels would make the parsers think the cell
+        has black text, triggering expensive OCR on empty cells.
+        
+        To remove these border lines, we search the top and bottom 10% of rows in the pixmap. If a
+        row has a continuous run of black pixels spanning >50% of the row width, replace the row
+        with all white pixels.
+        
+        A visualisation of the below vectorised implementation:
+        Original row:         B B B W B B W 
+        is_black:             1 1 1 0 1 1 0  whether the pixel is black
+        cumsum:               1 2 3 3 4 5 5  cumulative #. of black pixels so far
+        ~is_black:            0 0 0 1 0 0 1  whether the pixel is white
+        cumsum * (~is_black): 0 0 0 3 0 0 5  cumulative #. of black pixels at each white pixel
+        reset:                0 0 0 3 3 3 5  longest black run at the most recent white pixel
+                                             for white pixel: how long is the black run ending here
+                                             for black pixel: how long is the previous black run
+        run_length:           1 2 3 0 1 2 0  length of black pixel runs ending at each pixel
+        """
+        is_black = np.all(pixmap_arr < 50, axis=2)  # noqa: PLR2004
+        cumsum = np.cumsum(is_black, axis=1)
+        reset = np.maximum.accumulate(cumsum * (~is_black), axis=1)
+        run_lengths = cumsum - reset
+        max_run = run_lengths.max(axis=1)
+        border_band = max(1, pix_h // 10)
+        rows_idx = np.r_[0:border_band, pix_h - border_band:pix_h]
+        pixmap_arr[rows_idx[max_run[rows_idx] > pix_w * 0.5], :] = 255
+
+        # Also replace rows anywhere with black run > 80% of row width with all white pixels
+        pixmap_arr[max_run > pix_w * 0.8, :] = 255
+
         if np.sum(pixmap_arr < 50) < 10:  # noqa: PLR2004
             return []
 
@@ -503,7 +530,7 @@ class Page:
                         text=OCR_ERRORS.get(text, text),
                         bbox=self._transform_bbox(
                             bbox=bbox,
-                            from_page_bound=(0, 0, pixmap.width, pixmap.height),
+                            from_page_bound=(0, 0, pix_w, pix_h),
                             to_page_bound=clip
                         ))]
                 else:
@@ -517,7 +544,7 @@ class Page:
                             text=cleaned_text,
                             bbox=self._transform_bbox(
                                 bbox=tuple(i[0]),
-                                from_page_bound=(0, 0, pixmap.width, pixmap.height),
+                                from_page_bound=(0, 0, pix_w, pix_h),
                                 to_page_bound=clip
                             ))
                         )
@@ -603,7 +630,7 @@ class Page:
         np.maximum.at(longest_run_per_row, run_starts[0], run_length)
 
         # Whether a row is a black row (i.e., has a sufficiently long black run)
-        is_black_row: npt.NDArray[np.bool_] = (longest_run_per_row >= pixmap.width * min_length)
+        is_black_row: npt.NDArray[np.bool_] = (longest_run_per_row >= n_cols * min_length)
 
         # Sample down to original resolution
         """

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -177,7 +177,7 @@ class Page:
         # Save OCR input image for debugging if OCR_DEBUG_DIR is set
         global _ocr_debug_counter  # noqa: PLW0603
         if OCR_DEBUG_DIR is not None:
-            from PIL import Image
+            from PIL import Image  # noqa: PLC0415
             debug_dir = Path(OCR_DEBUG_DIR)
             debug_dir.mkdir(parents=True, exist_ok=True)
             _ocr_debug_counter += 1
@@ -473,13 +473,13 @@ class Page:
         The clip area may include a horizontal table border at its top or bottom edge. Even if the
         clip area has no black text, these black lines/pixels would make the parsers think the cell
         has black text, triggering expensive OCR on empty cells.
-        
+
         To remove these border lines, we search the top and bottom 10% of rows in the pixmap. If a
         row has a continuous run of black pixels spanning >50% of the row width, replace the row
         with all white pixels.
-        
+
         A visualisation of the below vectorised implementation:
-        Original row:         B B B W B B W 
+        Original row:         B B B W B B W
         is_black:             1 1 1 0 1 1 0  whether the pixel is black
         cumsum:               1 2 3 3 4 5 5  cumulative #. of black pixels so far
         ~is_black:            0 0 0 1 0 0 1  whether the pixel is white
@@ -507,9 +507,9 @@ class Page:
         a single black column could be the letter "l" (lowercase L) or "1" (one), so we only remove
         columns that are >95% black to avoid removing text.
         """
-        is_black_cols = np.all(pixmap_arr < 50, axis=2)
+        is_black_cols = np.all(pixmap_arr < 50, axis=2)  # TODO: magic value # noqa: PLR2004
         black_ratio_per_col = np.mean(is_black_cols, axis=0)
-        pixmap_arr[:, black_ratio_per_col > 0.95, :] = 255
+        pixmap_arr[:, black_ratio_per_col > 0.95, :] = 255  # TODO: magic value # noqa: PLR2004
 
         if np.sum(pixmap_arr < 50) < 10:  # noqa: PLR2004
             return []
@@ -520,7 +520,7 @@ class Page:
         # Save OCR input image for debugging if OCR_DEBUG_DIR is set
         global _ocr_debug_counter  # noqa: PLW0603
         if OCR_DEBUG_DIR is not None:
-            from PIL import Image
+            from PIL import Image  # noqa: PLC0415
             debug_dir = Path(OCR_DEBUG_DIR)
             debug_dir.mkdir(parents=True, exist_ok=True)
             _ocr_debug_counter += 1

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -670,7 +670,8 @@ class Page:
             tol: float = 3,
             allow_multiple_texts_per_cell: Optional[Sequence[int]] = None,
             header_included: bool = True,
-            check_strikeout: bool = True
+            check_strikeout: Optional[Sequence[int]] | bool = None,
+            parse_cols: Optional[set[int]] = None
     ) -> pd.DataFrame:
         """Parse a table cell by cell, defined by lines separating the cols. and rows
 
@@ -705,26 +706,42 @@ class Page:
                                               0
         :param header_included: whether the first row is header/col. names. Default is False, i.e.
                                 treat everything as table content, and no table header/col. names
-        :param check_strikeout: Whether to check for strikeout text in each cell. Set to `False`
-                                for PDFs that never contain strikeout text (e.g. entry lists) to
-                                avoid expensive per-textblock `search_for_black_lines` calls.
-                                Default is `True`
+        :param check_strikeout: Which cols. to check for strikeout text. Like
+                                `allow_multiple_texts_per_cell`, this is a list of col. indices.
+                                Only cells in these cols. will trigger the expensive per-textblock
+                                strikeout line check. Default is `None`, i.e. don't check anything.
+                                If `True`, then check everything. If `False`, then check nothing
+        :param parse_cols: Col. indices to parse. If provided, only these cols. will have
+                           `.get_text` called; all other cols. are filled with empty `TextBlock`.
+                           Use this to avoid expensive (potential OCR) text extraction for cols.
+                           whose data is not needed. Default is ``None``, i.e. parsed everything
         :return: A `pd.DataFrame`, with each cell being a TextBlock or a list of TextBlocks,
                  depending on `allow_multiple_texts_per_cell`
         """
         page_no_str = f'p.{self.number} in {self.file}'  # For error/warning messages
+        if check_strikeout is False:  # For backward compatibility
+            check_strikeout = None
+        elif check_strikeout is True:
+            check_strikeout = list(range(len(vlines) - 1))
 
         cells: list[list[Optional[TextBlock]]] = []
         for i in range(len(hlines) - 1):
             row = []
             for j in range(len(vlines) - 1):
+                # Skip cols. we don't need to save time
+                if (parse_cols is not None) and (j not in parse_cols):
+                    row.append(TextBlock(text=''))
+                    continue
+
                 l, t, r, b = vlines[j], hlines[i], vlines[j + 1], hlines[i + 1]
                 cell_bbox_str = f'({l:.1f}, {t:.1f}, {r:.1f}, {b:.1f})'  # For error/warnings
 
                 # Get text inside the cell defined by (l, t, r, b)
-                textblocks = self.get_text('dict',
-                                           clip=(l, t, r, b),
-                                           check_strikeout=check_strikeout)
+                textblocks = self.get_text(
+                    'dict',
+                    clip=(l, t, r, b),
+                    check_strikeout=(check_strikeout is not None) and (j in check_strikeout)
+                )
 
                 if not textblocks:
                     # OK to have an empty cell, e.g. the pit col. in quali. lap times PDF should be

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -69,6 +69,52 @@ class Page:
         self.file = file           # The PDF file path. Mainly for debug purpose
         self.w = page.bound()[2]   # Width and height, for convenience
         self.h = page.bound()[3]
+        self._pixmap_cache: dict[tuple[int, int], npt.NDArray[np.uint8]] = {}
+
+    def _get_full_page_pixmap(self, dpi: int) -> npt.NDArray[np.uint8]:
+        """Get the full-page pixmap at the given DPI and rotation, caching on first access"""
+        key = (dpi, self._pymupdf_page.rotation)
+        if key not in self._pixmap_cache:
+            pixmap: pymupdf.Pixmap = self._pymupdf_page.get_pixmap(dpi=dpi)
+            self._pixmap_cache[key] = (
+                np.frombuffer(buffer=pixmap.samples_mv, dtype=np.uint8)
+                .reshape((pixmap.height, pixmap.width, 3))
+                .copy()
+            )
+        return self._pixmap_cache[key]
+
+    def get_pixmap_array(self, clip: Optional['BBox'] = None, dpi: int = DPI, copy: bool = False) \
+            -> npt.NDArray[np.uint8]:
+        """Get page pixmap as a numpy array, sliced from a cached full-page render
+
+        The full page is rendered once per (DPI, rotation) pair and cached. Subsequent calls at the
+        same DPI and rotation return a slice of the cached array. There may be +/-1 px rounding
+        difference vs. a fresh `get_pixmap(clip=...)` call, which is negligible for structural
+        detection (white strips, grey/white rows, connected-component labelling, etc.).
+
+        :param clip: `(x0, y0, x1, y1)` in page coordinates. Default is `None`, i.e. full page
+        :param dpi: The DPI of the pixmap. Default is 600
+        :param copy: If `True`, return a deep copy so the caller can safely modify the array. If
+                     `False` (default), return a view/slice of the cached array. It's faster, but
+                     the caller **must not** modify it
+        :return: Pixmap in np.array of shape `(height, width, 3)`, dtype `uint8`
+        """
+        arr = self._get_full_page_pixmap(dpi)
+
+        if clip:
+            # Use current (possibly rotated) page bounds, not self.w/self.h which are always the
+            # original unrotated dimensions
+            bound = self._pymupdf_page.bound()
+            page_w, page_h = bound[2], bound[3]
+            scale_y: float = arr.shape[0] / page_h
+            scale_x: float = arr.shape[1] / page_w
+            px0 = max(0, int(round(clip[0] * scale_x)))
+            px1 = min(arr.shape[1], int(round(clip[2] * scale_x)))
+            py0 = max(0, int(round(clip[1] * scale_y)))
+            py1 = min(arr.shape[0], int(round(clip[3] * scale_y)))
+            arr = arr[py0:py1, px0:px1]
+
+        return arr.copy() if copy else arr
 
     def __getattr__(self, name: str):
         return getattr(self._pymupdf_page, name)  # If a method/attr. is not found, use PyMuPDF's
@@ -78,11 +124,9 @@ class Page:
 
         See https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/table-analysis/show_image.py
         """
-        pixmap = self.get_pixmap(clip=clip, dpi=DPI)
-        img = np.frombuffer(buffer=pixmap.samples_mv, dtype=np.uint8) \
-            .reshape((pixmap.height, pixmap.width, 3))
+        img = self.get_pixmap_array(clip=clip)
         plt.figure(dpi=DPI)
-        plt.imshow(img, extent=(0, pixmap.w * 72 / DPI, pixmap.h * 72 / DPI, 0))
+        plt.imshow(img, extent=(0, img.shape[1] * 72 / DPI, img.shape[0] * 72 / DPI, 0))
         plt.show()
         return
 
@@ -160,6 +204,7 @@ class Page:
             self,
             option: Literal['text', 'words', 'blocks', 'dict'] = 'text',
             small_area: bool = False,
+            check_strikeout: bool = True,
             **kwargs
     ) -> list['TextBlock']:
         """
@@ -170,6 +215,10 @@ class Page:
         there can be at most one superscript and at most one regular text in one `.get_text()`
         call, etc. That is, whenever we call `.get_text()` with `option=dict`, we are getting the
         text within a small area, e.g. a table cell
+
+        There is one additional parameter `check_strikeout` for perf. concern. Checking if there is
+        a strikeout line on top of a text needs some slow imaging processing, so we add this flag
+        to skip this step for PDFs that never have strikeout text (e.g. entry list PDFs)
         """
         if option not in {'text', 'words', 'blocks', 'dict'}:
             raise NotImplementedError(f'`option` can only be one of "text", "words", '
@@ -269,16 +318,22 @@ class Page:
                 case _:
                     raise ParsingError(error_message)
 
-            # When `option = dict`, also need to check if any strikeout text
-            for textblock in textblocks:
-                l, t, r, b = textblock.bbox
-                h = b - t
-                if self.search_for_black_lines(
-                        clip=(l, t + STRIKEOUT_LINE_MARGIN * h, r, b - STRIKEOUT_LINE_MARGIN * h),
-                        min_length=0.9,  # We are using the text's bbox, so relative to it, the
-                        rgb=192          # strikeout line should span almost the entire width
-                ):
-                    textblock.strikeout = True
+            # When `option = dict` and `check_strikeout = True`, need to check for strikeout text
+            if check_strikeout:
+                for textblock in textblocks:
+                    l, t, r, b = textblock.bbox
+                    h = b - t
+                    if self.search_for_black_lines(
+                            clip=(
+                                    l,
+                                    t + STRIKEOUT_LINE_MARGIN * h,
+                                    r,
+                                    b - STRIKEOUT_LINE_MARGIN * h
+                            ),
+                            min_length=0.9,  # We are using the text's bbox, so relative to it, the
+                            rgb=192          # strikeout line should span almost the entire width
+                    ):
+                        textblock.strikeout = True
             return textblocks
 
     @staticmethod
@@ -310,6 +365,7 @@ class Page:
             small_area: bool = False,
             expected: Optional[re.Pattern] = None,
             dpi: Optional[int] = DPI,
+            check_strikeout: bool = True,
             **kwargs
     ) -> list['TextBlock']:
         r"""This is `pymupdf.Page.get_text` w/ OCR functionality
@@ -334,6 +390,11 @@ class Page:
         :param dpi: The DPI for OCR. Higher DPI can improve OCR quality, but also significantly
                     slow down the OCR process. Will be ignored if we find text without OCR. Default
                     is 600, which is very slow but has great quality
+        :param check_strikeout: Whether to check for strikeout text when `option='dict'`. Each
+                                check calls `search_for_black_lines` per textblock, which renders
+                                a pixmap. Set to `False` to skip this (e.g. entry list PDFs never
+                                have strikeout text). Default is `True`. This flag is ignored if
+                                `option != 'dict'`
         :param kwargs: Other keyword arguments to pass to `pymupdf.Page.get_text`
         :return: A list of `TextBlock`s
         """
@@ -341,7 +402,8 @@ class Page:
             raise NotImplementedError('`expected` is not supported yet')
 
         # Try simple search first
-        if results := self._native_get_text(option, clip=clip, small_area=small_area, **kwargs):
+        if results := self._native_get_text(option, clip=clip, small_area=small_area,
+                                            check_strikeout=check_strikeout, **kwargs):
             return results
         logging.debug('No text found natively. Proceed with OCR')
 
@@ -553,9 +615,10 @@ class Page:
             self,
             vlines: list[float],
             hlines: list[float],
-            tol: float = 2,
+            tol: float = 3,
             allow_multiple_texts_per_cell: Optional[Sequence[int]] = None,
-            header_included: bool = True
+            header_included: bool = True,
+            check_strikeout: bool = True
     ) -> pd.DataFrame:
         """Parse a table cell by cell, defined by lines separating the cols. and rows
 
@@ -590,6 +653,10 @@ class Page:
                                               0
         :param header_included: whether the first row is header/col. names. Default is False, i.e.
                                 treat everything as table content, and no table header/col. names
+        :param check_strikeout: Whether to check for strikeout text in each cell. Set to `False`
+                                for PDFs that never contain strikeout text (e.g. entry lists) to
+                                avoid expensive per-textblock `search_for_black_lines` calls.
+                                Default is `True`
         :return: A `pd.DataFrame`, with each cell being a TextBlock or a list of TextBlocks,
                  depending on `allow_multiple_texts_per_cell`
         """
@@ -603,7 +670,9 @@ class Page:
                 cell_bbox_str = f'({l:.1f}, {t:.1f}, {r:.1f}, {b:.1f})'  # For error/warnings
 
                 # Get text inside the cell defined by (l, t, r, b)
-                textblocks = self.get_text('dict', clip=(l, t, r, b))
+                textblocks = self.get_text('dict',
+                                           clip=(l, t, r, b),
+                                           check_strikeout=check_strikeout)
 
                 if not textblocks:
                     # OK to have an empty cell, e.g. the pit col. in quali. lap times PDF should be
@@ -684,11 +753,8 @@ class Page:
         # TODO: this 4px height is very fragile. Better if get the exact vertical gap in pixels
         #       between two car No. and use (some proportion of) this gap as `height`
 
-        # Get the pixmap of the clipped area
-        pixmap: pymupdf.Pixmap = self.get_pixmap(clip=clip, dpi=DPI)
-        pixmap_arr: npt.NDArray[np.uint8] = (np.frombuffer(buffer=pixmap.samples_mv,
-                                                           dtype=np.uint8)
-                                             .reshape((pixmap.height, pixmap.width, 3)))
+        # Get the pixmap of the clipped area from cache
+        pixmap_arr: npt.NDArray[np.uint8] = self.get_pixmap_array(clip=clip)
 
         # Find all white rows, i.e. strictly all pixels in the row are white (RGB = 255)
         is_white: npt.NDArray[np.bool_] = np.all(pixmap_arr == 255, axis=(1, 2))  # noqa: PLR2004
@@ -706,7 +772,7 @@ class Page:
 
         # Filter out white strips that are less than `height`px tall, after DPI scaling
         strip_heights: npt.NDArray[np.intp] = ends - starts
-        scaling_factor: float = pixmap.height / (clip[3] - clip[1]) if clip else 1
+        scaling_factor: float = pixmap_arr.shape[0] / (clip[3] - clip[1]) if clip else 1
         is_valid_strip: npt.NDArray[np.bool_] = (strip_heights > height * scaling_factor)
 
         # Return the top y-coords. of the valid white strips, scaled back to the original page
@@ -739,12 +805,8 @@ class Page:
         :return: A list of numbers, where each number is the top y-coord. of a row. The bottom of
                  the last row is also included
         """
-        # Get the pixmap of the clipped area
-        pixmap: pymupdf.Pixmap = self.get_pixmap(clip=clip, dpi=DPI)
-        pixmap_arr: npt.NDArray[np.uint8] = (np.frombuffer(buffer=pixmap.samples_mv,
-                                                           dtype=np.uint8)
-                                             .reshape((pixmap.height, pixmap.width, 3))
-                                             .copy())
+        # Get the pixmap of the clipped area from cache
+        pixmap_arr: npt.NDArray[np.uint8] = self.get_pixmap_array(clip=clip)
 
         # Convert minimum row height requirement to the new DPI. E.g., if we scale the page from
         # 300 * 300 to 600 * 600, then 10px in the original page should become 20px
@@ -815,7 +877,7 @@ class Page:
         # Check if the first row is white. (If it's grey, then should already be captured above)
         # First check if have enough spacing (80% of a row height) above the first grey row
         t_first_grey_row = grey_rows[0][0] if grey_rows else clip[3]  # May have zero grey row
-        if t_first_grey_row > clip[1] + avg_row_height * 0.8:
+        if t_first_grey_row > clip[1] + avg_row_height * 0.75:
             # Then check if any text in the area above the first grey row
             text = self.get_text('text', clip=(clip[0], clip[1], clip[2], t_first_grey_row))
             if any(i.text for i in text):
@@ -832,7 +894,7 @@ class Page:
 
         # Check if the last row is white, in the same way
         b_last_grey_row = grey_rows[-1][1] if grey_rows else clip[1]
-        if b_last_grey_row < clip[3] - avg_row_height * 0.8:
+        if b_last_grey_row < clip[3] - avg_row_height * 0.75:
             text = self.get_text('text', clip=(clip[0], b_last_grey_row, clip[2], clip[3]))
             if any(i.text for i in text):
                 if avg_row_height:

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -717,7 +717,7 @@ class Page:
         :param hlines: y-coords. of horizontal lines separating the rows. Table top and bottom
                        boundaries need to be included
         :param tol: tolerance for text and cell positioning. In principle, all texts should fall
-                    inside the cell's bounding box. Default is 2 pixels, i.e. if text is within 2px
+                    inside the cell's bounding box. Default is 3 pixels, i.e. if text is within 3px
                     of the cell's boundary, it is considered to be inside the cell. If we find any
                     text more than 2px always from the cell's bbox, will raise an error. See #33
         :param allow_multiple_texts_per_cell: Which cols. can have multiple texts per cell. By
@@ -728,8 +728,8 @@ class Page:
                                               set this parameter to [0], i.e. allow col. 0 to have
                                               multiple textblocks per cell. Col. indexes start from
                                               0
-        :param header_included: whether the first row is header/col. names. Default is False, i.e.
-                                treat everything as table content, and no table header/col. names
+        :param header_included: whether the first row is header/col. names. Default is True, i.e.
+                                treat the first row as table header/col. names
         :param check_strikeout: Which cols. to check for strikeout text. Like
                                 `allow_multiple_texts_per_cell`, this is a list of col. indices.
                                 Only cells in these cols. will trigger the expensive per-textblock

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -19,6 +19,10 @@ import pymupdf
 from paddleocr import PaddleOCR
 
 from .._constants import DPI
+from ..utils import _detect_pymupdf_default_dpi
+
+# Get default DPI of PyMuPDF at runtime, which is 72 usually. Need this for scaling
+_PYMUPDF_DEFAULT_DPI: int = _detect_pymupdf_default_dpi()
 
 # Strikeout line location: it shouldn't be too close to the top or bottom of the text bbox
 STRIKEOUT_LINE_MARGIN = 0.2
@@ -133,7 +137,9 @@ class Page:
         """
         img = self.get_pixmap_array(clip=clip)
         plt.figure(dpi=DPI)
-        plt.imshow(img, extent=(0, img.shape[1] * 72 / DPI, img.shape[0] * 72 / DPI, 0))
+        scaling_factor = DPI / _PYMUPDF_DEFAULT_DPI
+        plt.imshow(img,
+                   extent=(0, img.shape[1] / scaling_factor, img.shape[0] / scaling_factor, 0))
         plt.show()
         return
 
@@ -550,14 +556,14 @@ class Page:
                  from top to bottom
         """
         # Get the pixmap of the clipped area
-        pixmap: pymupdf.Pixmap = self.get_pixmap(
-            clip=clip,
-            matrix=pymupdf.Matrix(scaling_factor, 0, 0, scaling_factor, 0, 0)
-        )
-        pixmap_arr: npt.NDArray[np.uint8] = (np.frombuffer(buffer=pixmap.samples_mv,
-                                                           dtype=np.uint8)
-                                             .reshape((pixmap.height, pixmap.width, 3))
-                                             .copy())
+        """
+        `scaling_factor` multiplies PyMuPDF's default 72 DPI, so `scaling_factor=4` translates to
+        72 * 4 = 288 DPI, `scaling_factor=16` -> 1152 DPI, etc. The full-page pixmap at this DPI
+        is rendered once and cached; subsequent calls with the same `scaling_factor` are then free
+        array slices.
+        """
+        dpi: int = scaling_factor * _PYMUPDF_DEFAULT_DPI
+        pixmap_arr: npt.NDArray[np.uint8] = self.get_pixmap_array(clip=clip, dpi=dpi)
         n_rows, n_cols, _ = pixmap_arr.shape
 
         # Whether a pixel is black (RGB < `rgb`). Shape = (n_rows, n_cols)

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -695,7 +695,7 @@ class Page:
             allow_multiple_texts_per_cell: Optional[Sequence[int]] = None,
             header_included: bool = True,
             check_strikeout: Optional[Sequence[int]] | bool = None,
-            parse_cols: Optional[set[int]] = None
+            parse_cols: Optional[Sequence[int]] = None
     ) -> pd.DataFrame:
         """Parse a table cell by cell, defined by lines separating the cols. and rows
 

--- a/fiadoc/parser/page.py
+++ b/fiadoc/parser/page.py
@@ -37,6 +37,20 @@ OCR_ERRORS = {
     '↓': '1'
 }
 
+# `Page.show_page` aesthetic settings
+# TODO: bad practice. Can override plot settings elsewhere
+rc = {'axes.facecolor': 'white',  # Remove background colour
+      'axes.grid': False,         # Turn on grid
+      'axes.linewidth': '0.2',
+      'axes.edgecolor': '0',      # Set axes edge color to be black
+      'font.size': 2,
+      'xtick.major.size': 1,
+      'xtick.major.width': 0.2,
+      'ytick.major.size': 1,
+      'ytick.major.width': 0.2,
+      'figure.autolayout': True}
+plt.rcdefaults()
+plt.rcParams.update(rc)
 
 @cache
 def get_ocr_instance():

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -1447,7 +1447,7 @@ class RaceParser(BaseParser):
             # a black line below the table header
             page = Page(page, file=self.history_chart_file)  # noqa: PLW2901
             page_no_str = f'p.{page.number} in {page.file}'
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
             history_chart = page.search_for('History Chart', clip=top_half, dpi=100)
             if len(history_chart) != 1:
                 doc.close()
@@ -1609,7 +1609,7 @@ class RaceParser(BaseParser):
             page_no_str = f'p.{page.number} in {page.file}'
 
             # Table header/col. names are below "Race Lap Chart"
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
             if lap_chart := page.search_for('Lap Chart', clip=top_half, dpi=100):
                 t_table_header = lap_chart[0].y1 + 1
             else:
@@ -1971,7 +1971,7 @@ class RaceParser(BaseParser):
             # Find "Sector Analysis"
             page = Page(page, file=self.sector_analysis_file)  # noqa: PLW2901
             page_no_str = f'p.{page.number} in {page.file}'
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
             sector_analysis = page.search_for('Sector Analysis', clip=top_half, dpi=100)
             if len(sector_analysis) != 1:
                 doc.close()
@@ -2340,7 +2340,7 @@ class QualifyingParser(BaseParser):
         for i in range(len(doc)):
             page = Page(doc[i], file=self.classification_file)  # noqa: PLW2901
             # Table/page title should appear in top half of the page
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
             if '.pdf' in page.get_text()[0].text:  # Fix #59
                 continue
             classification = page.search_for('Final Classification', clip=top_half, dpi=100)
@@ -3191,7 +3191,7 @@ class PitStopParser(BaseParser):
             page_no_str = f'p.{page.number} in {self.file}'
 
             # Locate "Pit Stop Summary" title
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
             pit_stop_summary = page.search_for('Pit Stop Summary', clip=top_half, dpi=100)
             if len(pit_stop_summary) != 1:
                 raise ParsingError(f'Find none or multiple "Pit Stop Summary" on {page_no_str}')

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -338,7 +338,7 @@ class EntryListParser(BaseParser):
                                       allow_multiple_texts_per_cell=[0],  # Allow superscripts
                                       header_included=False,
                                       tol=row_gap,
-                                      check_strikeout=False)
+                                      check_strikeout=None)
         df.columns = [i.text.lower() for i in cols]
         df = df.rename(columns={'no.': 'car_no'})
 
@@ -452,7 +452,7 @@ class EntryListParser(BaseParser):
                                                    allow_multiple_texts_per_cell=[0],
                                                    header_included=False,
                                                    tol=col_row_height * 0.3,
-                                                   check_strikeout=False)
+                                                   check_strikeout=None)
             reserves_df.columns = [i.text.lower() for i in cols]
             reserves_df = reserves_df.rename(columns={'no.': 'car_no'})
             reserves_df['reserve_for'] = reserves_df.car_no.apply(identify_reserve)
@@ -619,12 +619,13 @@ class PracticeParser(BaseParser):
         # Get cols.
         """
         Most cols. names can be easily parsed, except "NAT" and "ENTRANT", which are very close to
-        each other, and sometimes the gap between them is even smaller than the gap between two
-        chars. Therefore, we often get the two cols. as one "NAT ENTRANT". Below we try smaller and
+        each other, and sometimes the gap between them is even smaller than the width of a car.
+        Therefore, we often get the two cols. as one "NAT ENTRANT". Below we try smaller and
         smaller `col_min_gap`, until we get all expected cols. correctly. If even with a very small
-        `col_min_gap` we still can't get the cols. right, raise an error.
+        `col_min_gap` we still can't get the cols. right, then raise an error.
         """
         cols: Optional[list[TextBlock]] = None
+        expected_cols = EXPECTED_COLS['fp_classification']['required']
         for col_min_gap in [1, 0.9, 0.8, 0.7, 0.6, 0.5]:
             try:
                 cols = self._detect_cols(page,
@@ -633,10 +634,10 @@ class PracticeParser(BaseParser):
                 if not cols:
                     raise ParsingError(f'Could not locate cols. in the table header on '
                                        f'{page_no_str}')
-                if {i.text.lower() for i in cols} != EXPECTED_COLS['fp']['required']:
+                if {i.text.lower() for i in cols} != expected_cols:
                     raise ParsingError(
                         f'Got unexpected or miss some cols. on {page_no_str}. Expected: '
-                        f'{EXPECTED_COLS['fp']['required']}. Got: {[i.text for i in cols]}'
+                        f'{expected_cols}. Got: {[i.text for i in cols]}'
                     )
                 break
             except ParsingError:
@@ -644,11 +645,11 @@ class PracticeParser(BaseParser):
             except Exception as e:
                 doc.close()
                 raise e
-        if (not cols) or {i.text.lower() for i in cols} != EXPECTED_COLS['fp']['required']:
+        if (not cols) or {i.text.lower() for i in cols} != expected_cols:
             doc.close()
             raise ParsingError(
-                f'Got unexpected or miss some cols. on {page_no_str}. Expected: '
-                f'{EXPECTED_COLS['fp']['required']}. Got: {[i.text for i in cols]}'
+                f'Got unexpected or miss some cols. on {page_no_str}. Expected: {expected_cols}. '
+                f'Got: {[i.text for i in cols]}'
             )
         vlines = [0,
                   cols[0].bbox[0] - 1,
@@ -678,8 +679,16 @@ class PracticeParser(BaseParser):
                                                  min_height=col_row_height / 2)
 
         # Parse the table using the grid above
-        df = page.parse_table_by_grid(vlines=vlines, hlines=hlines, header_included=False,
-                                      allow_multiple_texts_per_cell=[2, 4])
+        # Only parse needed cols. (e.g. skip NAT, driver name, etc.) to avoid potentially expensive
+        # OCR text extraction. Col. 0 is finishing position, so we `i + 1` below.
+        to_parse = EXPECTED_COLS['fp_classification']['to_parse']
+        parse_cols = {0} | {i + 1 for i, col in enumerate(cols) if col.text.lower() in to_parse}
+        df = page.parse_table_by_grid(vlines=vlines,
+                                      hlines=hlines,
+                                      header_included=False,
+                                      allow_multiple_texts_per_cell=[2, 4],
+                                      parse_cols=parse_cols,
+                                      check_strikeout=None)
         # Allow multiple text blocks in "DRIVER" col. We don't need this col. at all, so don't care
         # if it's correctly parsed, as long as the car. No. col. is correct. The same applies to
         # "ENTRANT" col. as well
@@ -950,9 +959,13 @@ class PracticeParser(BaseParser):
                         )
 
                         # Parse the table
+                        check_strikeout = EXPECTED_COLS['fp_lap_times']['to_check_strikeout']
+                        check_strikeout = [i + 1 for i, c in enumerate(cols)
+                                           if c.text.lower() in check_strikeout]
                         df = page.parse_table_by_grid(vlines=vlines,
                                                       hlines=hlines,
-                                                      header_included=False)
+                                                      header_included=False,
+                                                      check_strikeout=check_strikeout or None)
                         if df.empty:
                             continue
                             # TODO: raise a warning here, as we found a driver with zero lap?
@@ -1906,9 +1919,13 @@ class RaceParser(BaseParser):
                             continue
 
                         # Parse the table
+                        check_strikeout = EXPECTED_COLS['race_lap_times']['to_check_strikeout']
+                        check_strikeout = [i + 1 for i, c in enumerate(cols)
+                                           if c.text.lower() in check_strikeout]
                         df = page.parse_table_by_grid(vlines=vlines,
                                                       hlines=hlines,
-                                                      header_included=False)
+                                                      header_included=False,
+                                                      check_strikeout=check_strikeout or None)
                         df.columns = ['lap', 'pit', 'lap_time']
                         df['lap_time_deleted'] = df.lap_time.apply(lambda x: x.strikeout is True)
                         df = df.map(self._normalise_textblock)
@@ -2113,10 +2130,15 @@ class RaceParser(BaseParser):
                         continue
 
                     # Parse the table
+                    # TODO: check strikeout index
+                    check_strikeout = EXPECTED_COLS['race_sector_analysis']['to_check_strikeout']
+                    check_strikeout = [i for i, c in enumerate(cols)
+                                       if c.text.lower() in check_strikeout]
                     df = page.parse_table_by_grid(vlines=vlines,
                                                   hlines=hlines,
                                                   header_included=False,
-                                                  allow_multiple_texts_per_cell=[0])
+                                                  allow_multiple_texts_per_cell=[0],
+                                                  check_strikeout=check_strikeout or None)
                     df.columns = ['lap', 'sector_1_time', 'sector_1_speed', 'sector_2_time',
                                   'sector_2_speed', 'sector_3_time', 'sector_3_speed', 'lap_time']
                     df['car_no'] = car_no
@@ -2917,9 +2939,13 @@ class QualifyingParser(BaseParser):
                             continue
 
                         # Parse the table
+                        check_strikeout = EXPECTED_COLS['quali_lap_times']['to_check_strikeout']
+                        check_strikeout = [i + 1 for i, c in enumerate(cols)
+                                           if c.text.lower() in check_strikeout]
                         df = page.parse_table_by_grid(vlines=vlines,
                                                       hlines=hlines,
-                                                      header_included=False)
+                                                      header_included=False,
+                                                      check_strikeout=check_strikeout or None)
                         df.columns = ['lap', 'pit', 'lap_time']
                         df['lap_time_deleted'] = df.lap_time.apply(
                             lambda x: x.strikeout is True)

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -2340,7 +2340,7 @@ class QualifyingParser(BaseParser):
         for i in range(len(doc)):
             page = Page(doc[i], file=self.classification_file)  # noqa: PLW2901
             # Table/page title should appear in top half of the page
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
             if '.pdf' in page.get_text()[0].text:  # Fix #59
                 continue
             classification = page.search_for('Final Classification', clip=top_half, dpi=100)
@@ -3191,7 +3191,7 @@ class PitStopParser(BaseParser):
             page_no_str = f'p.{page.number} in {self.file}'
 
             # Locate "Pit Stop Summary" title
-            top_half = (page.w * 0.1, page.h * 0.1, page.w * 0.9, page.h / 2)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
             pit_stop_summary = page.search_for('Pit Stop Summary', clip=top_half, dpi=100)
             if len(pit_stop_summary) != 1:
                 raise ParsingError(f'Find none or multiple "Pit Stop Summary" on {page_no_str}')
@@ -3216,9 +3216,9 @@ class PitStopParser(BaseParser):
             cols = self._detect_cols(page,
                                      clip=(0, t_table_header, page.w, b_table_header),
                                      col_min_gap=2)  # Very wide cols., so allow larger gaps
-            if [i.text for i in cols] != ['NO', 'DRIVER', 'ENTRANT', 'LAP', 'TIME OF DAY', 'STOP',
-                                          'DURATION', 'TOTAL TIME']:
-                raise ParsingError(f'Found unexpected or less cols. on {page_no_str}: {cols}')
+            if [i.text.lower() for i in cols] != EXPECTED_COLS['pit_stop_summary']['required']:
+                raise ParsingError(f'Found unexpected or less cols. on {page_no_str}. Got {cols}. '
+                                   f'Expected {EXPECTED_COLS["pit_stop_summary"]["required"]}')
 
             # Table bottom is the first white strip below the table header
             if white_strips := page.search_for_white_strips(
@@ -3233,7 +3233,8 @@ class PitStopParser(BaseParser):
             # Locate the horizontal positions of each col.
             col_pos = self._detect_cols(page,
                                         clip=(0, t_table_header, page.w, b_table),
-                                        col_min_gap=2)
+                                        col_min_gap=2,
+                                        get_text=False)
             if len(cols) != len(col_pos):
                 raise ParsingError(f'Number of detected cols. does not match number of col. names '
                                    f'on p.{page.number} in {self.file}: {cols} vs. {col_pos}')
@@ -3248,7 +3249,13 @@ class PitStopParser(BaseParser):
             )
 
             # Parse
-            df = page.parse_table_by_grid(vlines=vlines, hlines=hlines, header_included=False)
+            parse_cols = [i for i, col in enumerate(cols)
+                          if col.text.lower() in EXPECTED_COLS['pit_stop_summary']['to_parse']]
+            df = page.parse_table_by_grid(vlines=vlines,
+                                          hlines=hlines,
+                                          header_included=False,
+                                          parse_cols=parse_cols,
+                                          check_strikeout=None)
             df.columns = [i.text for i in cols]
             dfs.append(df)
 

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -1197,12 +1197,12 @@ class RaceParser(BaseParser):
         if not cols:
             doc.close()
             raise ParsingError(f'Could not locate cols. in the table header on {page_no_str}')
-        expected_cols = EXPECTED_COLS['race_classification']['required']
+        req_cols = EXPECTED_COLS['race_classification']['required']
         col_names_lower = {i.text.lower() for i in cols}
-        if col_names_lower < expected_cols:
+        if not req_cols.issubset(col_names_lower):
             doc.close()
             raise ParsingError(f'Got unexpected or miss some cols. on {page_no_str}. Expected: '
-                               f'{expected_cols}. Got: {[i.text for i in cols]}')
+                               f'{req_cols}. Got: {[i.text for i in cols]}')
         vlines = [0,
                   cols[0].bbox[0] - 1,
                   (cols[0].bbox[2] + cols[1].bbox[0]) / 2,
@@ -2394,7 +2394,7 @@ class QualifyingParser(BaseParser):
         # Check required cols. are present
         req_cols = EXPECTED_COLS['quali_classification']['required']
         detected_cols = {name.lower() for name in col_name_to_tb}
-        if detected_cols < req_cols:
+        if not req_cols.issubset(detected_cols):
             doc.close()
             raise ParsingError(f'Missing required cols. {req_cols} in {self.classification_file}. '
                                f'Got: {detected_cols}')

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -157,8 +157,8 @@ class BaseParser:
             texts = page.get_text('text', clip=(l, t, r, b), small_area=True)
             if len(texts) != 1:
                 raise ParsingError(f'Expected one text block for col. name. Found {texts} inside '
-                                   f'({clip[0]:.2f}, {clip[1]:.2f}, {clip[2]:.2f}, {clip[3]:.2f}) '
-                                   f'on p.{page.number} in {page.file}')
+                                   f'({l:.2f}, {t:.2f}, {r:.2f}, {b:.2f}) on p.{page.number} in '
+                                   f'{page.file}')
             text = texts[0]
             if text.text:
                 # The "/" in "KM/H" is often mis-OCRed. Manually correct it here

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -2369,6 +2369,14 @@ class QualifyingParser(BaseParser):
         col_name_to_tb = {i.text: i for i in cols}  # Col. name --> its TextBlock
         col_row_height = np.mean([i.bbox[3] - i.bbox[1] for i in cols])
 
+        # Check required cols. are present
+        req_cols = EXPECTED_COLS['quali_classification']['required']
+        detected_cols = {name.lower() for name in col_name_to_tb}
+        if detected_cols < req_cols:
+            doc.close()
+            raise ParsingError(f'Missing required cols. {req_cols} in {self.classification_file}. '
+                               f'Got: {detected_cols}')
+
         # The table ends with a white strip below the table header
         if white_strips:= page.search_for_white_strips(clip=(0, t_table_body, page.w, page.h),
                                                        height=col_row_height / 3):
@@ -2475,7 +2483,14 @@ class QualifyingParser(BaseParser):
                                                  min_height=col_row_height / 3)
 
         # Get the table
-        df = page.parse_table_by_grid(vlines=vlines, hlines=hlines, header_included=False)
+        to_parse = EXPECTED_COLS['quali_classification']['to_parse']
+        parse_cols = {0} | {i + 1 for i, col_name in enumerate(col_name_to_tb)
+                            if col_name.lower() in to_parse}
+        df = page.parse_table_by_grid(vlines=vlines,
+                                      hlines=hlines,
+                                      parse_cols=parse_cols,
+                                      check_strikeout=None,
+                                      header_included=False)
         df.columns = ['position'] + [i for i in col_name_to_tb.keys()]
         df['finishing_status'] = 0
         df['original_order'] = range(1, len(df) + 1)  # Driver's original order in the PDF
@@ -2499,7 +2514,9 @@ class QualifyingParser(BaseParser):
                                                      min_height=col_row_height / 3)
             not_classified = page.parse_table_by_grid(vlines=vlines,
                                                       hlines=hlines,
-                                                      header_included=False)
+                                                      header_included=False,
+                                                      parse_cols=parse_cols,
+                                                      check_strikeout=None)
             not_classified.columns = df.columns.drop(['finishing_status', 'original_order',
                                                       'is_classified'])
             not_classified.position = None  # No finishing position for unclassified drivers
@@ -2539,7 +2556,9 @@ class QualifyingParser(BaseParser):
                                                          min_height=col_row_height / 3)
                 disqualified = page.parse_table_by_grid(vlines=vlines,
                                                         hlines=hlines,
-                                                        header_included=False)
+                                                        header_included=False,
+                                                        parse_cols=parse_cols,
+                                                        check_strikeout=None)
                 disqualified.columns = df.columns.drop(['finishing_status', 'original_order',
                                                         'is_classified'])
                 disqualified.position = None  # No finishing position for DSQ drivers

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -2318,8 +2318,8 @@ class QualifyingParser(BaseParser):
         for i in range(len(doc)):
             page = Page(doc[i], file=self.classification_file)  # noqa: PLW2901
             # Table/page title should appear in top half of the page
-            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
-            if '.pdf' in page.get_text(clip=top_half, dpi=300)[0].text:  # Fix #59
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
+            if '.pdf' in page.get_text()[0].text:  # Fix #59
                 continue
             classification = page.search_for('Final Classification', clip=top_half, dpi=100)
             if classification:
@@ -2430,9 +2430,9 @@ class QualifyingParser(BaseParser):
         # Boundary between Q1_TIME and Q2
         page.set_rotation(90)
         black_lines = page.search_for_black_lines(clip=(page.h - b_table,
-                                                  col_name_to_tb['Q1_TIME'].r,
-                                                  page.h - t_table_body,
-                                                  col_name_to_tb['Q2'].l),
+                                                        col_name_to_tb['Q1_TIME'].r,
+                                                        page.h - t_table_body,
+                                                        col_name_to_tb['Q2'].l),
                                                   scaling_factor=16)
         if len(black_lines) != 1:
             doc.close()
@@ -2482,9 +2482,11 @@ class QualifyingParser(BaseParser):
         df['is_classified'] = True
 
         # Parse "NOT CLASSIFIED" table, if any
-        if not_classified := page.search_for('NOT CLASSIFIED',
-                                             clip=(0, b_table, page.w, page.h),
-                                             dpi=300):
+        if not_classified := page.search_for(
+                'NOT CLASSIFIED',
+                clip=(page.w * 0.4, b_table, page.w * 0.6, page.h * 0.95),
+                dpi=300
+        ):
             t_table_body = not_classified[0].y1 + 1
             if white_strips:= page.search_for_white_strips(clip=(0, t_table_body, page.w, page.h),
                                                            height=col_row_height / 3):
@@ -2510,9 +2512,11 @@ class QualifyingParser(BaseParser):
         df = _pd_concat([df, not_classified])
 
         # Parse "DISQUALIFIED" table, if any
-        if disqualified := page.search_for('DISQUALIFIED',
-                                           clip=(0, b_table, page.w, page.h),
-                                           dpi=300):
+        if disqualified := page.search_for(
+                'DISQUALIFIED',
+                clip=(page.w * 0.4, b_table, page.w * 0.6, page.h * 0.95),
+                dpi=300
+        ):
             """
             There can be multiple "DISQUALIFIED" text. E.g., in the penalty notes, we may have
             "DISQUALIFIED", and we may have "DISQUALIFIED" as the table title. The table title
@@ -2745,7 +2749,7 @@ class QualifyingParser(BaseParser):
             # Find "Lap Times"
             page = Page(page, file=self.lap_times_file)  # noqa: PLW2901
             page_no_str = f'p.{page.number} in {self.lap_times_file}'
-            top_half = (page.w * 0.1, page.h * 0.1, page.w * 0.9, page.h / 2)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.3)
             quali_lap_times = page.search_for('Lap Times', clip=top_half, dpi=100)
             if len(quali_lap_times) != 1:
                 doc.close()
@@ -3080,7 +3084,7 @@ class QualifyingParser(BaseParser):
         # TODO: Very bad. Why did I create this method???
         lap_data = []
         # TODO: first lap's lap time is calendar time, not lap time, so drop it
-        # Lap No. can be missing (e.g.#47)
+        # Lap No. can be missing (e.g. #47)
         df = df[(df.lap_no >= 2) | df.lap_no.isna()].copy()  # noqa: PLR2004
         df.lap_time = df.lap_time.apply(duration_to_millisecond)
         for q in [1, 2, 3]:

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pymupdf
 from scipy.ndimage import find_objects, label
 
-from .._constants import DPI, EXPECTED_COLS, QUALI_DRIVERS, REGULAR_DRIVERS
+from .._constants import EXPECTED_COLS, QUALI_DRIVERS, REGULAR_DRIVERS
 from ..drivers import Drivers
 from ..models.classification import SessionEntryImport, SessionEntryObject
 from ..models.driver import (
@@ -90,11 +90,8 @@ class BaseParser:
                                       of `clip`, are ignored
         :return: List of TextBlock representing the detected cols.
         """
-        # Get the pixmap of `clip` area
-        # TODO: create a get pixmap method in Page
-        pixmap: pymupdf.Pixmap = page.get_pixmap(clip=clip, dpi=DPI)
-        arr: npt.NDArray[np.uint8] = (np.frombuffer(buffer=pixmap.samples_mv, dtype=np.uint8)
-                                      .reshape((pixmap.height, pixmap.width, 3)))
+        # Get the pixmap of `clip` area from cache
+        arr: npt.NDArray[np.uint8] = page.get_pixmap_array(clip=clip, copy=True)
 
         # Replace rows and cols. w/ almost all black pixels with white pixels (those are lines not
         # text). After this step, all black pixels should be texts only
@@ -340,7 +337,8 @@ class EntryListParser(BaseParser):
                                       hlines=hlines,
                                       allow_multiple_texts_per_cell=[0],  # Allow superscripts
                                       header_included=False,
-                                      tol=row_gap)
+                                      tol=row_gap,
+                                      check_strikeout=False)
         df.columns = [i.text.lower() for i in cols]
         df = df.rename(columns={'no.': 'car_no'})
 
@@ -453,7 +451,8 @@ class EntryListParser(BaseParser):
                                                    hlines=hlines_reserve,
                                                    allow_multiple_texts_per_cell=[0],
                                                    header_included=False,
-                                                   tol=col_row_height * 0.3)
+                                                   tol=col_row_height * 0.3,
+                                                   check_strikeout=False)
             reserves_df.columns = [i.text.lower() for i in cols]
             reserves_df = reserves_df.rename(columns={'no.': 'car_no'})
             reserves_df['reserve_for'] = reserves_df.car_no.apply(identify_reserve)

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -55,7 +55,8 @@ class BaseParser:
             page: Page,
             clip: BBox,
             col_min_gap: float = 1.1,
-            min_black_line_length: float = 0.9
+            min_black_line_length: float = 0.9,
+            get_text: bool = True
     ) -> list[TextBlock]:
         """
         Search for table header/cols. in the `clip` area
@@ -88,6 +89,10 @@ class BaseParser:
                                       black vertical lines longer than 90% of the height of `clip`,
                                       and any black horizontal lines longer than 90% of the width
                                       of `clip`, are ignored
+        :param get_text: Whether to extract the text of the detected cols. Default is `True`.
+                         Sometimes we only care about the location of the cols., but not the col.
+                         names, e.g. locating row positions in (the rotated) lap chart PDFs. In
+                         such cases, set this to `False` to save time
         :return: List of TextBlock representing the detected cols.
         """
         # Get the pixmap of `clip` area from cache
@@ -154,6 +159,9 @@ class BaseParser:
             t -= 1
             r += 1
             b += 1
+            if not get_text:  # Sometimes we only need the positions, but not the text
+                cols.append(TextBlock(text='', bbox=(l, t, r, b)))
+                continue
             texts = page.get_text('text', clip=(l, t, r, b), small_area=True)
             if len(texts) != 1:
                 raise ParsingError(f'Expected one text block for col. name. Found {texts} inside '
@@ -1439,7 +1447,7 @@ class RaceParser(BaseParser):
             # a black line below the table header
             page = Page(page, file=self.history_chart_file)  # noqa: PLW2901
             page_no_str = f'p.{page.number} in {page.file}'
-            top_half = (page.w * 0.1, page.h * 0.1, page.w * 0.9, page.h / 2)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
             history_chart = page.search_for('History Chart', clip=top_half, dpi=100)
             if len(history_chart) != 1:
                 doc.close()
@@ -1601,7 +1609,7 @@ class RaceParser(BaseParser):
             page_no_str = f'p.{page.number} in {page.file}'
 
             # Table header/col. names are below "Race Lap Chart"
-            top_half = (page.w * 0.1, page.h * 0.1, page.w * 0.9, page.h / 2)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
             if lap_chart := page.search_for('Lap Chart', clip=top_half, dpi=100):
                 t_table_header = lap_chart[0].y1 + 1
             else:
@@ -1683,7 +1691,8 @@ class RaceParser(BaseParser):
             rows = self._detect_cols(
                 page,
                 clip=(t_table_body + 1, page.w - l_first_col - 1, b_table, page.w),
-                col_min_gap=0.3
+                col_min_gap=0.3,
+                get_text=False
             )
             page.set_rotation(0)
             if not rows:
@@ -1962,7 +1971,7 @@ class RaceParser(BaseParser):
             # Find "Sector Analysis"
             page = Page(page, file=self.sector_analysis_file)  # noqa: PLW2901
             page_no_str = f'p.{page.number} in {page.file}'
-            top_half = (page.w * 0.3, page.h * 0.1, page.w * 0.7, page.h / 4)
+            top_half = (page.w * 0.2, page.h * 0.1, page.w * 0.8, page.h * 0.4)
             sector_analysis = page.search_for('Sector Analysis', clip=top_half, dpi=100)
             if len(sector_analysis) != 1:
                 doc.close()
@@ -2143,15 +2152,15 @@ class RaceParser(BaseParser):
                         continue
 
                     # Parse the table
-                    # TODO: check strikeout index
-                    check_strikeout = EXPECTED_COLS['race_sector_analysis']['to_check_strikeout']
-                    check_strikeout = [i for i, c in enumerate(cols)
-                                       if c.text.lower() in check_strikeout]
+                    # TODO: probably shouldn't hardcode the indices
+                    check_strikeout = [len(cols) - 1]
+                    to_parse = [0, len(cols) - 1]
                     df = page.parse_table_by_grid(vlines=vlines,
                                                   hlines=hlines,
                                                   header_included=False,
                                                   allow_multiple_texts_per_cell=[0],
-                                                  check_strikeout=check_strikeout or None)
+                                                  parse_cols=to_parse,
+                                                  check_strikeout=check_strikeout)
                     df.columns = ['lap', 'sector_1_time', 'sector_1_speed', 'sector_2_time',
                                   'sector_2_speed', 'sector_3_time', 'sector_3_speed', 'lap_time']
                     df['car_no'] = car_no

--- a/fiadoc/parser/parser.py
+++ b/fiadoc/parser/parser.py
@@ -1154,8 +1154,8 @@ class RaceParser(BaseParser):
         classification: Optional[list[TextBlock]] = None
         for page in doc:
             page = Page(page, file=self.classification_file)  # noqa: PLW2901
-            top_half = (page.w * 0.1, page.h * 0.1, page.w * 0.9, page.h / 2)
-            if '.pdf' in page.get_text(clip=top_half, dpi=300)[0].text:  # Fix #59
+            top_half = (page.w * 0.1, page.h * 0.1, page.w * 0.9, page.h * 0.3)
+            if '.pdf' in page.get_text()[0].text:  # Fix #59
                 continue
             classification = page.search_for('Final Classification', clip=top_half, dpi=100)
             if classification:
@@ -1189,14 +1189,12 @@ class RaceParser(BaseParser):
         if not cols:
             doc.close()
             raise ParsingError(f'Could not locate cols. in the table header on {page_no_str}')
-        if [i.text.upper() for i in cols] != ['NO', 'DRIVER', 'NAT', 'ENTRANT', 'LAPS', 'TIME',
-                                              'GAP', 'INT', 'KM/H', 'FASTEST', 'ON', 'PTS']:
+        expected_cols = EXPECTED_COLS['race_classification']['required']
+        col_names_lower = {i.text.lower() for i in cols}
+        if col_names_lower < expected_cols:
             doc.close()
-            raise ParsingError(
-                f'Got unexpected or miss some cols. on {page_no_str}. Expected "NO", "DRIVER", '
-                f'"NAT", "ENTRANT", "LAPS", "TIME", "GAP", "INT", "KM/H", "FASTEST", "ON", and '
-                f'"PTS". Got: {[i.text for i in cols]}'
-            )
+            raise ParsingError(f'Got unexpected or miss some cols. on {page_no_str}. Expected: '
+                               f'{expected_cols}. Got: {[i.text for i in cols]}')
         vlines = [0,
                   cols[0].bbox[0] - 1,
                   (cols[0].bbox[2] + cols[1].bbox[0]) / 2,
@@ -1226,8 +1224,16 @@ class RaceParser(BaseParser):
                                                  min_height=col_row_height / 2)
 
         # Parse the table using the grid above
-        df = page.parse_table_by_grid(vlines=vlines, hlines=hlines, header_included=False,
-                                      allow_multiple_texts_per_cell=[2, 4])
+        # Only parse needed cols. (e.g. skip driver, nat, entrant, int, km/h) to avoid potentially
+        # expensive text extraction. Col. 0 is finishing position, so we `i + 1` below.
+        to_parse = EXPECTED_COLS['race_classification']['to_parse']
+        parse_cols = {0} | {i + 1 for i, col in enumerate(cols) if col.text.lower() in to_parse}
+        df = page.parse_table_by_grid(vlines=vlines,
+                                      hlines=hlines,
+                                      allow_multiple_texts_per_cell=[2, 4],
+                                      parse_cols=parse_cols,
+                                      check_strikeout=None,
+                                      header_included=False)
         df.columns = ['finishing_position', 'car_no', 'driver', 'nat', 'team', 'laps_completed',
                       'time', 'gap', 'int', 'avg_speed', 'fastest_lap_time', 'fastest_lap_no',
                       'points']
@@ -1241,10 +1247,11 @@ class RaceParser(BaseParser):
         """
 
         # Check if there is a "NOT CLASSIFIED" table below the main table
-        not_classified = page.search_for('NOT CLASSIFIED',
-                                         clip=(0, b_table + 1, page.w, page.h),
-                                         dpi=300)
-
+        not_classified = page.search_for(
+            'NOT CLASSIFIED',
+            clip=(page.w * 0.4, b_table + 1, page.w * 0.6, page.h * 0.95),
+            dpi=300
+        )
         # If yes, repeat the above for the "NOT CLASSIFIED" table
         if not_classified:
             if black_lines := page.search_for_black_lines(
@@ -1270,8 +1277,10 @@ class RaceParser(BaseParser):
                                                      min_height=col_row_height / 3)
             not_classified = page.parse_table_by_grid(vlines=vlines,
                                                       hlines=hlines,
-                                                      header_included=False,
-                                                      allow_multiple_texts_per_cell=[2, 4])
+                                                      allow_multiple_texts_per_cell=[2, 4],
+                                                      parse_cols=parse_cols,
+                                                      check_strikeout=None,
+                                                      header_included=False)
             not_classified.columns = df.columns
             not_classified.position = None  # No finishing position for unclassified drivers
             not_classified = not_classified.map(self._normalise_textblock, merge_multi_tbs=True)
@@ -1280,9 +1289,11 @@ class RaceParser(BaseParser):
             not_classified = pd.DataFrame(columns=df.columns)
 
         # Repeat the same for "DISQUALIFIED" table, if any
-        disqualified = page.search_for('DISQUALIFIED',
-                                       clip=(0, b_table + 1, page.w, page.h),
-                                       dpi=300)
+        disqualified = page.search_for(
+            'DISQUALIFIED',
+            clip=(page.w * 0.4, b_table + 1, page.w * 0.6, page.h * 0.95),
+            dpi=300
+        )
         if disqualified:
             if black_lines := page.search_for_black_lines(
                     clip=(0, disqualified[0].y1, page.w, page.h)
@@ -1307,8 +1318,10 @@ class RaceParser(BaseParser):
                                                      min_height=col_row_height / 3)
             disqualified = page.parse_table_by_grid(vlines=vlines,
                                                     hlines=hlines,
-                                                    header_included=False,
-                                                    allow_multiple_texts_per_cell=[2, 4])
+                                                    allow_multiple_texts_per_cell=[2, 4],
+                                                    parse_cols=parse_cols,
+                                                    check_strikeout=None,
+                                                    header_included=False)
             disqualified.columns = df.columns
             disqualified.position = None  # No finishing position for disqualified drivers
             disqualified = disqualified.map(self._normalise_textblock, merge_multi_tbs=True)

--- a/fiadoc/tests/test_page.py
+++ b/fiadoc/tests/test_page.py
@@ -242,7 +242,8 @@ def test_page_parse_table_by_grid(page, vlines, hlines, tol, allow_multiple_text
                                       hlines=hlines,
                                       tol=tol,
                                       allow_multiple_texts_per_cell=allow_multiple_texts_per_cell,
-                                      header_included=header_included)
+                                      header_included=header_included,
+                                      check_strikeout=True)
     pd.testing.assert_frame_equal(result,
                                   expected,
                                   check_dtype=False,

--- a/fiadoc/utils.py
+++ b/fiadoc/utils.py
@@ -7,25 +7,29 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-import matplotlib.pyplot as plt
 import pandas as pd
 import pymupdf
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-rc = {'figure.figsize': (8, 6),
-      'axes.facecolor': 'white',  # Remove background colour
-      'axes.grid': False,         # Turn on grid
-      'axes.linewidth': '0.2',
-      'axes.edgecolor': '0',      # Set axes edge color to be black
-      'font.size': 2,
-      'xtick.major.size': 1,
-      'xtick.major.width': 0.2,
-      'ytick.major.size': 1,
-      'ytick.major.width': 0.2}
-plt.rcdefaults()
-plt.rcParams.update(rc)
+
+def _detect_pymupdf_default_dpi() -> int:
+    """Derive PyMuPDF's default DPI empirically
+
+    PDF points are defined as 1 / 72 inch (ISO 32000), and PyMuPDF's identity matrix maps 1 point
+    -> 1 pixel, giving a default of 72 DPI.  Rather than hardcoding that 72 value (because I don't
+    really trust PyMuPDF...), we derive it empirically: render a tiny blank page at the identity
+    matrix and at a known DPI, then solve `base_dpi = known_dpi * identity_width / known_width`.
+    """
+    _doc = pymupdf.open()
+    _doc.new_page(width=100, height=100)
+    _page = _doc[0]
+    _w_identity: int = _page.get_pixmap().width
+    _known_dpi: int = 100
+    _w_known: int = _page.get_pixmap(dpi=_known_dpi).width
+    _doc.close()
+    return round(_known_dpi * _w_identity / _w_known)
 
 
 def duration_to_millisecond(s: str | None) -> dict[str, str | int] | None:

--- a/scripts/profiler.py
+++ b/scripts/profiler.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python
+"""
+Collects wall time (mean +/- std over `--repeat` runs) and top `--hotspots` cProfile hotspots for
+every main method. Results are written to a Markdown file for easy review.
+
+Usage
+-----
+    python profiler.py --repeat 5 --hotspots 10 --output report.md
+"""
+import argparse
+import cProfile
+import logging
+import pstats
+import statistics
+import sys
+import time
+import traceback
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import paddlex
+from paddleocr import logger
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from fiadoc.parser import (
+    EntryListParser,
+    PitStopParser,
+    PracticeParser,
+    QualifyingParser,
+    RaceParser,
+)
+
+# Suppress PaddleOCR logging
+logger.setLevel(logging.ERROR)
+paddlex.utils.logging._logger.setLevel(logging.ERROR)
+
+PDF_DIR = Path('data/pdf')
+_FIXTURES = {
+    # EntryListParser
+    'entry_list': '2026_1_entry_list.pdf',
+
+    # PracticeParser
+    'fp_classification': '2026_1_fp1_classification.pdf',
+    'fp_lap_times': '2026_1_fp1_lap_times.pdf',
+
+    # QualifyingParser
+    'quali_classification': '2026_1_quali_final_classification.pdf',
+    'quali_lap_times': '2026_1_quali_lap_times.pdf',
+
+    # RaceParser
+    'race_classification': '2026_1_race_classification.pdf',
+    'race_lap_analysis': '2026_1_race_lap_analysis.pdf',
+    'race_history_chart': '2026_1_race_history_chart.pdf',
+    'race_lap_chart': '2026_1_race_lap_chart.pdf',
+    'race_sector_analysis': '2026_1_race_sector_analysis.pdf',
+
+    # PitStopParser
+    'pit_stop': '2026_1_race_pit_stop_summary.pdf',
+}
+_F = {k: PDF_DIR / v for k, v in _FIXTURES.items()}  # Resolved absolute paths
+
+_shared: dict = {}  # Mutable container for sharing parser instances between setup and run
+
+
+def _entry_list_parse() -> None:
+    """EntryListParser._parse (called inside __init__)."""
+    p = EntryListParser(_F['entry_list'], year=2026, round_no=1)
+    p._parse()
+
+
+def _fp_parse_classification() -> None:
+    p = PracticeParser(classification_file=_F['fp_classification'], lap_times_file=None,
+                       year=2026, round_no=1, session='fp1')
+    p._parse_classification()
+
+
+def _fp_lap_times_setup() -> None:
+    """
+    Create `PracticeParser` and pre-parse classification so it's cached. Otherwise,
+    `._parse_lap_times()` will pick `_parse_classification()` times
+    """
+    p = PracticeParser(classification_file=_F['fp_classification'],
+                       lap_times_file=_F['fp_lap_times'],
+                       year=2026, round_no=1, session='fp1')
+    _ = p.classification_df  # populate cached_property
+    _shared['fp_parser'] = p
+
+
+def _fp_parse_lap_times() -> None:
+    _shared['fp_parser']._parse_lap_times()
+
+
+def _quali_parse_classification() -> None:
+    p = QualifyingParser(classification_file=_F['quali_classification'], lap_times_file=None,
+                         year=2026, round_no=1, session='quali')
+    p._parse_classification()
+
+
+def _quali_lap_times_setup() -> None:
+    """Similar to `_fp_lap_times_setup()`"""
+    p = QualifyingParser(classification_file=_F['quali_classification'],
+                         lap_times_file=_F['quali_lap_times'],
+                         year=2026, round_no=1, session='quali')
+    _ = p.classification_df  # populate cached_property
+    _shared['quali_parser'] = p
+
+
+def _quali_parse_lap_times() -> None:
+    _shared['quali_parser']._parse_lap_times()
+
+
+def _race_parse_classification() -> None:
+    p = RaceParser(classification_file=_F['race_classification'],
+                   lap_analysis_file=None, history_chart_file=None, lap_chart_file=None,
+                   sector_analysis_file=None,
+                   year=2026, round_no=1, session='race')
+    p._parse_classification()
+
+
+def _race_parse_lap_analysis() -> None:
+    p = RaceParser(classification_file=None,
+                   lap_analysis_file=_F['race_lap_analysis'],
+                   history_chart_file=None, lap_chart_file=None, sector_analysis_file=None,
+                   year=2026, round_no=1, session='race',)
+    p._parse_lap_analysis()
+
+
+def _race_parse_history_chart() -> None:
+    p = RaceParser(classification_file=None,
+                   history_chart_file=_F['race_history_chart'],
+                   lap_analysis_file=None, lap_chart_file=None, sector_analysis_file=None,
+                   year=2026, round_no=1, session='race')
+    p._parse_history_chart()
+
+
+def _race_parse_lap_chart() -> None:
+    p = RaceParser(classification_file=None,
+                   lap_chart_file=_F['race_lap_chart'],
+                   lap_analysis_file=None, history_chart_file=None, sector_analysis_file=None,
+                   year=2026, round_no=1, session='race')
+    p._parse_lap_chart()
+
+
+def _race_parse_sector_analysis() -> None:
+    p = RaceParser(classification_file=None,
+                   sector_analysis_file=_F['race_sector_analysis'],
+                   lap_analysis_file=None, history_chart_file=None, lap_chart_file=None,
+                   year=2026, round_no=1, session='race')
+    p._parse_sector_analysis()
+
+
+def _pit_stop_parse() -> None:
+    """PitStopParser._parse (called inside __init__)."""
+    p = PitStopParser(_F['pit_stop'], year=2026, round_no=1, session='race')
+    p._parse()
+
+
+@dataclass
+class Benchmark:
+    parser_name: str
+    method_name: str
+    fn: Callable[[], None]
+    required_files: list[str]
+    setup: Callable[[], None] | None = None  # Called once before all runs (e.g. pre-parse deps)
+
+
+@dataclass
+class BenchmarkResult:
+    label: str
+    times: list[float] = field(default_factory=list)
+    hotspots: list[dict] = field(default_factory=list)
+    error: str | None = None
+
+
+BENCHMARKS: list[Benchmark] = [
+    Benchmark('EntryListParser',
+              '_parse',
+              _entry_list_parse,
+              ['entry_list']),
+
+    Benchmark('PracticeParser',
+              '_parse_classification',
+              _fp_parse_classification,
+              ['fp_classification']),
+
+    Benchmark('PracticeParser',
+              '_parse_lap_times',
+              _fp_parse_lap_times,
+              ['fp_classification', 'fp_lap_times'],
+              setup=_fp_lap_times_setup),
+
+    Benchmark('QualifyingParser',
+              '_parse_classification',
+              _quali_parse_classification,
+              ['quali_classification']),
+
+    Benchmark('QualifyingParser',
+              '_parse_lap_times',
+              _quali_parse_lap_times,
+              ['quali_classification', 'quali_lap_times'],
+              setup=_quali_lap_times_setup),
+
+    Benchmark('RaceParser',
+              '_parse_classification',
+              _race_parse_classification,
+              ['race_classification']),
+
+    Benchmark('RaceParser',
+              '_parse_lap_analysis',
+              _race_parse_lap_analysis,
+              ['race_lap_analysis']),
+
+    Benchmark('RaceParser',
+              '_parse_history_chart',
+              _race_parse_history_chart,
+              ['race_history_chart']),
+
+    Benchmark('RaceParser',
+              '_parse_lap_chart',
+              _race_parse_lap_chart,
+              ['race_lap_chart']),
+
+    Benchmark('RaceParser',
+              '_parse_sector_analysis',
+              _race_parse_sector_analysis,
+              ['race_sector_analysis']),
+
+    Benchmark('PitStopParser',
+              '_parse',
+              _pit_stop_parse,
+              ['pit_stop'])
+]
+
+
+def _shorten_path(path: str) -> str:
+    """Collapse long absolute paths into something readable"""
+    for marker in ('fiadoc/', 'site-packages/'):
+        idx = path.find(marker)
+        if idx != -1:
+            return path[idx:]
+    return path.rsplit('/', 1)[-1] if '/' in path else path
+
+
+def _extract_hotspots(pr: cProfile.Profile, n: int) -> list[dict]:
+    """Return top `n` functions sorted by self-time (tottime)."""
+    stats = pstats.Stats(pr)
+    # stats.stats: {(file, line, name): (cc, nc, tt, ct, callers)}
+    items = sorted(stats.stats.items(), key=lambda x: x[1][2], reverse=True)
+    hotspots = []
+    for (filepath, lineno, funcname), (_, ncalls, tottime, cumtime, _) in items[:n]:
+        hotspots.append({
+            'function': funcname,
+            'source': f'{_shorten_path(filepath)}:{lineno}',
+            'ncalls': ncalls,
+            'tottime': tottime,
+            'cumtime': cumtime,
+        })
+    return hotspots
+
+
+def _run_benchmark(bm: Benchmark, n_repeat: int, n_hotspots: int) -> BenchmarkResult:
+    """Execute a single benchmark: warm-up -> timing runs -> cProfile"""
+    label = f'{bm.parser_name}.{bm.method_name}'
+    result = BenchmarkResult(label=label)
+
+    # Check that required PDF fixtures exist
+    missing = [k for k in bm.required_files if not _F[k].exists()]
+    if missing:
+        result.error = f'Missing fixture(s): {", ".join(_FIXTURES[k] for k in missing)}'
+        return result
+
+    try:
+        # Setup (e.g. pre-parse dependencies so they are cached)
+        if bm.setup:
+            bm.setup()
+
+        # Warm-up (discard)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            bm.fn()
+
+        # Timing runs
+        for _ in range(n_repeat):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                t0 = time.perf_counter()
+                bm.fn()
+                t1 = time.perf_counter()
+            result.times.append(t1 - t0)
+
+        # cProfile run
+        pr = cProfile.Profile()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            pr.enable()
+            bm.fn()
+            pr.disable()
+        result.hotspots = _extract_hotspots(pr, n_hotspots)
+
+    except:  # noqa: E722
+        result.error = traceback.format_exc()
+
+    return result
+
+
+def _fmt(val: float) -> str:
+    """Format seconds to a human-friendly millisecond"""
+    return f'{val * 1000:.1f} ms'
+
+
+def _write_markdown(results: list[BenchmarkResult], path: Path, n_repeat: int) -> None:
+    lines: list[str] = []
+    w = lines.append
+
+    w('# Profiler Results\n')
+    w(f'- **Generated**: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")}')
+    w(f'- **Python**: {sys.version.split()[0]}')
+    w(f'- **Repeats per method**: {n_repeat}\n')
+
+    w('## Summary\n')
+    w('| Parser | Method | Mean | Std | Min | Max |')
+    w('|--------|--------|------|-----|-----|-----|')
+    for r in results:
+        parser, method = r.label.split('.', 1)
+        if r.error:
+            w(f'| {parser} | `{method}` | — | — | — | — | error |')
+            continue
+        if not r.times:
+            w(f'| {parser} | `{method}` | — | — | — | — | skipped |')
+            continue
+        mean = statistics.mean(r.times)
+        std = statistics.stdev(r.times) if len(r.times) > 1 else 0.0
+        mn, mx = min(r.times), max(r.times)
+        w(f'| {parser} | `{method}` | {_fmt(mean)} | {_fmt(std)} '
+          f'| {_fmt(mn)} | {_fmt(mx)} |')
+
+    w('\n## Hotspots (by self-time)\n')
+    for r in results:
+        if r.error or not r.hotspots:
+            continue
+
+        w(f'### {r.label}\n')
+        w('| # | Function | Source | Calls | Self-time | Cum-time |')
+        w('|---|----------|--------|------:|----------:|---------:|')
+        for i, h in enumerate(r.hotspots, 1):
+            w(f'| {i} | `{h["function"]}` | `{h["source"]}` '
+              f'| {h["ncalls"]} | {_fmt(h["tottime"])} | {_fmt(h["cumtime"])} |')
+        w('')
+
+    errors = [r for r in results if r.error]
+    if errors:
+        w('## Errors\n')
+        for r in errors:
+            w(f'### {r.label}\n')
+            w('```')
+            w(r.error.rstrip())
+            w('```\n')
+
+    path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    return
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--repeat', type=int, default=5,
+                    help='Number of timing runs per method (default: 5)')
+    ap.add_argument('--output', type=str, default='profiler_results.md',
+                    help='Path to the output Markdown file (default: profiler_results.md)')
+    ap.add_argument('--hotspots', type=int, default=10,
+                    help='Number of top hotspots to show per method (default: 10)')
+    args = ap.parse_args()
+
+    total = len(BENCHMARKS)
+    results: list[BenchmarkResult] = []
+
+    print(f'Running profiler  --  {args.repeat} repeats, {args.hotspots} hotspots')
+    print(f'Output: {args.output}')
+    print('=' * 72)
+
+    for i, bm in enumerate(BENCHMARKS, 1):
+        label = f'{bm.parser_name}.{bm.method_name}'
+        print(f'[{i}/{total}] {label}... ', end='', flush=True)
+
+        result = _run_benchmark(bm, n_repeat=args.repeat, n_hotspots=args.hotspots)
+        results.append(result)
+
+        if result.error:
+            print('ERROR')
+        elif result.times:
+            mean = statistics.mean(result.times)
+            std = statistics.stdev(result.times) if len(result.times) > 1 else 0.0
+            print(f'{_fmt(mean).removesuffix(" ms")} +/- {_fmt(std)}')
+        else:
+            print('skipped')
+
+    print('=' * 72)
+
+    out = Path(args.output)
+    _write_markdown(results, out, n_repeat=args.repeat)
+    print(f'Results written to {out.resolve()}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_with_ocr_debug.py
+++ b/scripts/run_with_ocr_debug.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Run RaceParser with OCR debug mode to capture OCR input images"""
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from fiadoc.parser import QualifyingParser
+from fiadoc.parser import page as page_module
+
+# Enable OCR debug mode
+debug_dir = Path('debug_ocr')
+page_module.OCR_DEBUG_DIR = str(debug_dir)
+
+print("OCR Debug Mode: Enabled")
+print(f"Debug directory: {debug_dir.absolute()}")
+print(f"OCR images will be saved to: {debug_dir.absolute()}\n")
+
+# Run the parser
+print("=" * 72)
+print("Running RaceParser with OCR debug mode...\n")
+
+parser = QualifyingParser(
+    classification_file='data/pdf/2026_1_quali_final_classification.pdf',
+    lap_times_file=None,
+    year=2026,
+    round_no=1,
+    session='quali'
+)
+
+try:
+    _ = parser._parse_classification()
+    print('Parsing completed successfully')
+except Exception as e:
+    print(f'Error: {e}\n')
+    raise

--- a/scripts/run_with_ocr_debug.py
+++ b/scripts/run_with_ocr_debug.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Run RaceParser with OCR debug mode to capture OCR input images"""
+"""Run the parser with OCR debug mode to capture OCR input images"""
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
this makes the parser faster by 66%. Previously the test suites take ~30 minutes to finish on github actions, and now it only takes ~10 minutes.

Main performance gains come from:

* skip unnecessary cols. in parsing, e.g. country flag col. This also reduces OCR calls a lot
* cache pixmap. `Page.get_text()` and other methods used to generate a new pixmap (of a clipped area) every time they were called. Now we create and cache the full page's pixmap once and clip from this cached pixmap
* reduce OCR area size. E.g., we know the table/page title must appear around the middle of a page, so we don't need to OCR the full width; the middle part of the page is enough
* remove table vertical and horizontal borders before OCR, so we can skip OCR some empty cells better
* only check if a text is strikeout when needed. That is, only lap times can be deleted and strikeout, and all other cols. don't need this check. This saves a bit image processing time